### PR TITLE
Feat/pdf plain text

### DIFF
--- a/flowise-embed/src/constants.ts
+++ b/flowise-embed/src/constants.ts
@@ -16,3 +16,7 @@ export const defaultBotPropsAnalise: BubblePropsCriticalAnalysis = {
   theme: undefined,
   observersConfig: undefined,
 };
+
+export const constants = {
+  apiUtilsUrl: 'https://ca-ai-utils-api-prod-eastus2-001.bravepond-9830b784.eastus2.azurecontainerapps.io',
+};

--- a/flowise-embed/src/service/aiUtilsApi.ts
+++ b/flowise-embed/src/service/aiUtilsApi.ts
@@ -1,0 +1,11 @@
+import { constants } from "@/constants";
+
+const apiHost = constants.apiUtilsUrl;
+export const pdfToText = async (file: Blob): Promise<Response> => {
+  const form = new FormData();
+  form.append('file', file);
+  return fetch(`${apiHost}/text-extraction/pdf-to-text`, {
+    method: 'POST',
+    body: form,
+  });
+};

--- a/flowise-embed/src/service/aiUtilsApi.ts
+++ b/flowise-embed/src/service/aiUtilsApi.ts
@@ -1,4 +1,4 @@
-import { constants } from "@/constants";
+import { constants } from '@/constants';
 
 const apiHost = constants.apiUtilsUrl;
 export const pdfToText = async (file: Blob): Promise<Response> => {

--- a/flowise-embed/src/service/aiUtilsApi.ts
+++ b/flowise-embed/src/service/aiUtilsApi.ts
@@ -4,7 +4,7 @@ const apiHost = constants.apiUtilsUrl;
 export const pdfToText = async (file: Blob): Promise<Response> => {
   const form = new FormData();
   form.append('file', file);
-  return fetch(`${apiHost}/text-extraction/pdf-to-text`, {
+  return fetch(`${apiHost}/text-extraction/plain-text`, {
     method: 'POST',
     body: form,
   });


### PR DESCRIPTION
Adiciona plain text do pdf no processo de extração de dados do checklist para otimizar o resultado final.

- adiciona api utils para extrair texto de pdf com unstructured
- adiciona extração ao processo
- envia novo formato de mensagem para o flowise: checklist ... plain-text: ... json: 


Alteração de prompt necessária (apenas primeiras linhas do checklist:

Você fará o papel de um OCR utilizando de uma imagem de um pdf e um plain-text extraído do mesmo.
Apenas extraia o texto da imagem e retorne exatamente como está descrito no arquivo, ajustando a sintaxe conforme presente no plain-text.

|com plain text para revalidar | sem plain-text|
|---|---|
|<img width="447" alt="Captura de Tela 2024-09-27 às 14 11 23" src="https://github.com/user-attachments/assets/e2283453-e976-432e-9a7e-e16d3af79427">|<img width="361" alt="Captura de Tela 2024-09-27 às 14 11 29" src="https://github.com/user-attachments/assets/b18e3b04-3158-43bf-9119-d3d49d61b63b">|