### PR TITLE
Fix/image upload

### DIFF
--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -893,11 +893,11 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
 
   const readImagesUrls = (imagesToUpload: any[]) => {
     // Logic from handleSubmit function
-    const urls = imagesToUpload.map((item) => {
+    const urls = imagesToUpload.map((item, index) => {
       return {
         data: item.data,
         type: item.type,
-        name: item.name,
+        name: item.name.split('.')[0] + (index) + '.' + item.name.split('.')[1],
         mime: item.mime,
       };
     });


### PR DESCRIPTION
- Ajusta um erro que pode ser somente um bug visual mas tem grandes chances de estar impactando em todos os resultados. 

As imagens enviadas para o Langsmith (e provavelmente para a openai) estavam indo iguais por conta de um gerenciamento de cache com nomes de arquivos iguais. Para isso modifiquei o nome, agora normalizando o comportamento.

https://github.com/user-attachments/assets/83e6d83a-6347-4318-82ff-f4c232b47d4f



Agora normalizado

https://github.com/user-attachments/assets/1ed7260a-0f63-4ef7-80af-025eb8ad73bc

