### PR TITLE
[ACI-17] - Armazenar hash dos documentos processados

### DIFF
--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -25,7 +25,7 @@ import { UploadFile } from '@solid-primitives/upload';
 import { NextChecklistButton } from '@/components/buttons/NextChecklistButton';
 import { isImage } from '@/utils/isImage';
 import { FileMapping } from '@/utils/fileUtils';
-import { convertPdfToMultipleImages, pdfToText, pdfToBase64 } from '@/utils/pdfUtils';
+import { convertPdfToMultipleImages, pdfToText, pdfToSHA256 } from '@/utils/pdfUtils';
 import {
   defaultChecklist,
   conferencesDefault,
@@ -1075,11 +1075,11 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   };
 
   const extractDocumentData = async (fileMap: any, textContent: any, agentResult?: any) => {
-    const pdfBase64 = await pdfToBase64(fileMap.file.file);
+    const pdfSHA256 = await pdfToSHA256(fileMap.file.file);
     return {
       file_name: fileMap.file.file.name,
       file_extension: fileMap.file.file.type,
-      hash: pdfBase64,
+      hash: pdfSHA256,
       checklist_result: fileMap.filledChecklist || agentResult,
       extraction_result: fileMap.content || agentResult,
       pdf_to_text: textContent,

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1000,7 +1000,6 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   };
 
   const sendBackgroundMessage = async (value: string, urls: any[]) => {
-    console.log('passou aqui', value);
     const body: IncomingInput = {
       question: value,
       chatId: chatId(),

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1308,7 +1308,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
 
     const fileProcessed = await documentService.checkDocumentForAlreadyProcessedData(fileMap, props.flow);
 
-    if (fileProcessed != null) {
+    if (fileProcessed) {
       let processedDocumentJson = JSON.parse(fileProcessed);
       processedDocumentJson = sanitizeJson(processedDocumentJson);
       await processCriticalAnalysisUpdate(processedDocumentJson, true);

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1101,6 +1101,23 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     await saveDocumentData(documentData);
   };
 
+  const checkDocumentHash = async (pdfSHA256: any): Promise<any> => {
+    const documentService = new DocumentsDBService();
+    try {
+      const result = await documentService.isHashInDatabase(pdfSHA256);
+      return result;
+    } catch (error) {
+      console.error('Error checking hash on database:', error);
+      return null;
+    }
+  };
+
+  const extractSHA256AndCheckDocumentHash = async (fileMap: any): Promise<any> => {
+    const pdfSHA256 = await pdfToSHA256(fileMap.file.file);
+    const fileProcessed = await checkDocumentHash(pdfSHA256);
+    return fileProcessed?.checklist_result;
+  };
+
   const processFileToSend = async (file: File) => {
     let imagesList: File[] = [];
 
@@ -1127,6 +1144,130 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     }
   };
 
+  const extractNewChecklist = async (file: any, fileMap: any, urls: any) => {
+    const maxAttempts = 3;
+    const textContent = await getTextContent(file.file);
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const checklistPrompt = `CHECKLIST\n${fileMap.checklist}\n\nPlain-text: ${textContent}\n\njson: `;
+        const resultFromBackgroundMessage = await sendBackgroundMessage(checklistPrompt, urls);
+
+        let jsonData = JSON.parse(resultFromBackgroundMessage.text);
+        jsonData = sanitizeJson(jsonData);
+
+        if (Object.keys(jsonData).includes('error') && Object.keys(jsonData).length === 1) {
+          throw new Error(jsonData.error);
+        }
+
+        fileMap.content = jsonData;
+        fileMap.filledChecklist = jsonData;
+
+        if (!Object.keys(jsonData).includes('checklist')) {
+          throw new Error(messageUtils.CHECKLIST_NOT_FOUND_IN_RESPONSE_ERROR);
+        }
+
+        extractAndSaveDocumentData(fileMap, textContent);
+        structureAndSaveMessages(jsonData, fileMap, resultFromBackgroundMessage);
+
+        break;
+      } catch (error) {
+        console.error(error);
+        if (attempt === maxAttempts) {
+          const errorMessage = messageUtils.UNABLE_TO_PROCESS_CHECKLIST_MESSAGE;
+
+          setMessages((prevMessages) => [...prevMessages, { message: errorMessage, type: 'apiMessage' }]);
+        }
+      }
+    }
+
+    setIsNextChecklistButtonDisabled(false);
+    setLoading(false);
+  };
+
+  const structureAndSaveMessages = async (jsonData: any, fileMap: any, resultFromBackgroundMessage?: any) => {
+    const generateChecklistItemToPrint = (key: string, value: any) => {
+      if (value && typeof value === 'object') {
+        const formatted_value = Object.entries(value)
+          .map(([key, value]) => {
+            return `${key}: ${value}`;
+          })
+          .join('<br>');
+        value = formatted_value;
+      }
+
+      const spacedText = (text: string) => `<div style="padding-left: 20px; margin-bottom: 10px;">${text}</div>`;
+      const getMessage = (key: string, value: any, validValue: boolean, justificationNotFound: boolean) => {
+        const isSuccessfulMessage = validValue && !justificationNotFound;
+        if (isSuccessfulMessage) {
+          return spacedText(value);
+        } else {
+          const defaultNotFoundMessage = justificationNotFound ? value : 'Não identificado';
+          const signatureKey = 'Assinatura';
+          const messageNotFoundSignature = 'A assinatura não foi identificada, por favor verifique manualmente!';
+          const isSignatureKey = key === signatureKey;
+          const message = isSignatureKey ? messageNotFoundSignature : defaultNotFoundMessage;
+
+          return spacedText(`<span style="color: ${colorTheme.errorColor};">${message}</span>`);
+        }
+      };
+
+      const isValidValue = value !== null && customBooleanValues.NOT_FOUND.toString() !== value;
+      const hasJustificationNotFound = value && value.includes(customBooleanValues.FALSE_WITH_JUSTIFICATION.toString());
+      const shouldCheckboxBeChecked = isValidValue && !hasJustificationNotFound;
+
+      let checklistItem = `<input type="checkbox" ${shouldCheckboxBeChecked ? 'checked' : ''} disabled> <b>${key}</b>:<br>`;
+      checklistItem += getMessage(key, value, isValidValue, hasJustificationNotFound);
+
+      return checklistItem;
+    };
+
+    let checklistMessage = `<b>${fileMap.type}:</b><br>`;
+
+    for (const [key, value] of Object.entries(jsonData.checklist)) {
+      checklistMessage += generateChecklistItemToPrint(key, value);
+    }
+
+    if (Object.keys(jsonData).includes('conferências') && Object.keys(jsonData['conferências']).length > 0) {
+      checklistMessage += `<br><b>Conferências:</b><br>`;
+      for (const [key, value] of Object.entries(jsonData['conferências'])) {
+        checklistMessage += generateChecklistItemToPrint(key, value);
+      }
+    }
+
+    setMessages((prevMessages) => [...prevMessages, { message: checklistMessage, type: 'apiMessage' }]);
+
+    const conferences = jsonData['conferências'];
+
+    if (
+      conferences &&
+      ((Object.keys(conferences).includes('Máquina/Equipamento') && conferences['Máquina/Equipamento'] === 'true') ||
+        (Object.keys(conferences).includes('Possui Ex-tarifário') && conferences['Possui Ex-tarifário'] === 'true'))
+    ) {
+      setMessages((prevMessages) => [...prevMessages, { message: messageUtils.EX_TARIFF_CHECK_ALERT_MESSAGE, type: 'apiMessage' }]);
+    }
+
+    if (!isChatFlowAvailableToStream()) {
+      updateLastMessage(
+        checklistMessage,
+        resultFromBackgroundMessage?.sourceDocuments || null,
+        resultFromBackgroundMessage?.fileAnnotations || null,
+        resultFromBackgroundMessage?.agentReasoning || null,
+        resultFromBackgroundMessage?.action || null,
+        checklistMessage,
+      );
+    } else {
+      updateLastMessage(
+        '',
+        resultFromBackgroundMessage?.sourceDocuments || null,
+        resultFromBackgroundMessage?.fileAnnotations || null,
+        resultFromBackgroundMessage?.agentReasoning || null,
+        resultFromBackgroundMessage?.action || null,
+        checklistMessage,
+      );
+    }
+  };
+
   const processNextChecklist = async () => {
     setUploading(true);
     setLoading(true);
@@ -1149,126 +1290,16 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     setUploading(false);
     setMessages((prevMessages) => [...prevMessages, { message: `${file.name}`, type: 'userMessage', fileUploads: urls }]);
 
-    const textContent = await getTextContent(file.file);
+    const fileProcessed = await extractSHA256AndCheckDocumentHash(fileMap);
 
-    const extractChecklist = async () => {
-      const maxAttempts = 3;
+    if (fileProcessed != null) {
+      let processedDocumentJson = JSON.parse(fileProcessed);
+      processedDocumentJson = sanitizeJson(processedDocumentJson);
+      structureAndSaveMessages(processedDocumentJson, fileMap);
+    } else {
+      await extractNewChecklist(file, fileMap, urls);
+    }
 
-      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-        try {
-          const checklistPrompt = `CHECKLIST\n${fileMap.checklist}\n\nPlain-text: ${textContent}\n\njson: `;
-          const resultFromBackgroundMessage = await sendBackgroundMessage(checklistPrompt, urls);
-          let jsonData = JSON.parse(resultFromBackgroundMessage.text);
-          jsonData = sanitizeJson(jsonData);
-
-          if (Object.keys(jsonData).includes('error') && Object.keys(jsonData).length === 1) {
-            throw new Error(jsonData.error);
-          }
-
-          fileMap.content = jsonData;
-          fileMap.filledChecklist = jsonData;
-
-          if (!Object.keys(jsonData).includes('checklist')) {
-            throw new Error(messageUtils.CHECKLIST_NOT_FOUND_IN_RESPONSE_ERROR);
-          }
-
-          extractAndSaveDocumentData(fileMap, textContent);
-
-          const generateChecklistItemToPrint = (key: string, value: any) => {
-            if (value && typeof value === 'object') {
-              const formatted_value = Object.entries(value)
-                .map(([key, value]) => {
-                  return `${key}: ${value}`;
-                })
-                .join('<br>');
-              value = formatted_value;
-            }
-
-            const spacedText = (text: string) => `<div style="padding-left: 20px; margin-bottom: 10px;">${text}</div>`;
-            const getMessage = (key: string, value: any, validValue: boolean, justificationNotFound: boolean) => {
-              const isSuccessfulMessage = validValue && !justificationNotFound;
-              if (isSuccessfulMessage) {
-                return spacedText(value);
-              } else {
-                const defaultNotFoundMessage = justificationNotFound ? value : 'Não identificado';
-                const signatureKey = 'Assinatura';
-                const messageNotFoundSignature = 'A assinatura não foi identificada, por favor verifique manualmente!';
-                const isSignatureKey = key === signatureKey;
-                const message = isSignatureKey ? messageNotFoundSignature : defaultNotFoundMessage;
-
-                return spacedText(`<span style="color: ${colorTheme.errorColor};">${message}</span>`);
-              }
-            };
-
-            const isValidValue = value !== null && customBooleanValues.NOT_FOUND.toString() !== value;
-            const hasJustificationNotFound = value && value.includes(customBooleanValues.FALSE_WITH_JUSTIFICATION.toString());
-            const shouldCheckboxBeChecked = isValidValue && !hasJustificationNotFound;
-
-            let checklistItem = `<input type="checkbox" ${shouldCheckboxBeChecked ? 'checked' : ''} disabled> <b>${key}</b>:<br>`;
-            checklistItem += getMessage(key, value, isValidValue, hasJustificationNotFound);
-
-            return checklistItem;
-          };
-
-          let checklistMessage = `<b>${fileMap.type}:</b><br>`;
-
-          for (const [key, value] of Object.entries(jsonData.checklist)) {
-            checklistMessage += generateChecklistItemToPrint(key, value);
-          }
-
-          if (Object.keys(jsonData).includes('conferências') && Object.keys(jsonData['conferências']).length > 0) {
-            checklistMessage += `<br><b>Conferências:</b><br>`;
-            for (const [key, value] of Object.entries(jsonData['conferências'])) {
-              checklistMessage += generateChecklistItemToPrint(key, value);
-            }
-          }
-
-          setMessages((prevMessages) => [...prevMessages, { message: checklistMessage, type: 'apiMessage' }]);
-
-          const conferences = jsonData['conferências'];
-
-          if (
-            conferences &&
-            ((Object.keys(conferences).includes('Máquina/Equipamento') && conferences['Máquina/Equipamento'] === 'true') ||
-              (Object.keys(conferences).includes('Possui Ex-tarifário') && conferences['Possui Ex-tarifário'] === 'true'))
-          ) {
-            setMessages((prevMessages) => [...prevMessages, { message: messageUtils.EX_TARIFF_CHECK_ALERT_MESSAGE, type: 'apiMessage' }]);
-          }
-
-          if (!isChatFlowAvailableToStream()) {
-            updateLastMessage(
-              checklistMessage,
-              resultFromBackgroundMessage?.sourceDocuments,
-              resultFromBackgroundMessage?.fileAnnotations,
-              resultFromBackgroundMessage?.agentReasoning,
-              resultFromBackgroundMessage?.action,
-              checklistMessage,
-            );
-          } else {
-            updateLastMessage(
-              '',
-              resultFromBackgroundMessage?.sourceDocuments,
-              resultFromBackgroundMessage?.fileAnnotations,
-              resultFromBackgroundMessage?.agentReasoning,
-              resultFromBackgroundMessage?.action,
-              checklistMessage,
-            );
-          }
-          break;
-        } catch (error) {
-          console.error(error);
-          if (attempt === maxAttempts) {
-            const errorMessage = messageUtils.UNABLE_TO_PROCESS_CHECKLIST_MESSAGE;
-
-            setMessages((prevMessages) => [...prevMessages, { message: errorMessage, type: 'apiMessage' }]);
-          }
-        }
-      }
-
-      setIsNextChecklistButtonDisabled(false);
-      setLoading(false);
-    };
-    await extractChecklist();
     try {
       setLoading(true);
 

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1161,15 +1161,14 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
         const isSuccessfulMessage = validValue && !justificationNotFound;
         if (isSuccessfulMessage) {
           return spacedText(value);
-        } else {
-          const defaultNotFoundMessage = justificationNotFound ? value : 'Não identificado';
-          const signatureKey = 'Assinatura';
-          const messageNotFoundSignature = 'A assinatura não foi identificada, por favor verifique manualmente!';
-          const isSignatureKey = key === signatureKey;
-          const message = isSignatureKey ? messageNotFoundSignature : defaultNotFoundMessage;
-
-          return spacedText(`<span style="color: ${colorTheme.errorColor};">${message}</span>`);
         }
+        const defaultNotFoundMessage = justificationNotFound ? value : 'Não identificado';
+        const signatureKey = 'Assinatura';
+        const messageNotFoundSignature = 'A assinatura não foi identificada, por favor verifique manualmente!';
+        const isSignatureKey = key === signatureKey;
+        const message = isSignatureKey ? messageNotFoundSignature : defaultNotFoundMessage;
+
+        return spacedText(`<span style="color: ${colorTheme.errorColor};">${message}</span>`);
       };
 
       const isValidValue = value !== null && customBooleanValues.NOT_FOUND.toString() !== value;

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -454,9 +454,14 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     });
   };
 
-  const processCriticalAnalysisUpdate = async (jsonCriticalAnalysisUpdate: any) => {
+  const processCriticalAnalysisUpdate = async (jsonCriticalAnalysisUpdate: any, processedFile?: boolean) => {
     try {
-      const jsonDataCriticalAnalysis = JSON.parse(jsonCriticalAnalysisUpdate.text);
+      let jsonDataCriticalAnalysis;
+      if (processedFile) {
+        jsonDataCriticalAnalysis = jsonCriticalAnalysisUpdate;
+      } else {
+        jsonDataCriticalAnalysis = JSON.parse(jsonCriticalAnalysisUpdate.text);
+      }
 
       for (const key in jsonDataCriticalAnalysis) {
         const normalizedKey = removeAccents(key);
@@ -469,8 +474,6 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
           jsonDataCriticalAnalysis[key] = normalizeLocationNames(jsonDataCriticalAnalysis[key], locationValues.COUNTRY);
         }
       }
-
-      jsonCriticalAnalysisUpdate.text = JSON.stringify(jsonDataCriticalAnalysis);
 
       setJsonResponseCriticalAnalysis(jsonDataCriticalAnalysis);
 
@@ -493,30 +496,33 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
         setStartUploadingDocument(true);
         setIsUploadButtonDisabled(true);
 
+        jsonCriticalAnalysisUpdate.text = JSON.stringify(jsonDataCriticalAnalysis);
+
         const parallelApiExecutor = new ParallelApiExecutor({
           jsonCriticalAnalysisUpdate,
           setMessages,
         });
 
         await parallelApiExecutor.execute();
+
         setLoading(false);
       }
 
       if (!isChatFlowAvailableToStream()) {
         updateLastMessage(
           criticalAnalysisMessage,
-          jsonCriticalAnalysisUpdate?.sourceDocuments,
-          jsonCriticalAnalysisUpdate?.fileAnnotations,
-          jsonCriticalAnalysisUpdate?.agentReasoning,
-          jsonCriticalAnalysisUpdate?.action,
+          jsonCriticalAnalysisUpdate?.sourceDocuments || null,
+          jsonCriticalAnalysisUpdate?.fileAnnotations || null,
+          jsonCriticalAnalysisUpdate?.agentReasoning || null,
+          jsonCriticalAnalysisUpdate?.action || null,
         );
       } else {
         updateLastMessage(
           '',
-          jsonCriticalAnalysisUpdate?.sourceDocuments,
-          jsonCriticalAnalysisUpdate?.fileAnnotations,
-          jsonCriticalAnalysisUpdate?.agentReasoning,
-          jsonCriticalAnalysisUpdate?.action,
+          jsonCriticalAnalysisUpdate?.sourceDocuments || null,
+          jsonCriticalAnalysisUpdate?.fileAnnotations || null,
+          jsonCriticalAnalysisUpdate?.agentReasoning || null,
+          jsonCriticalAnalysisUpdate?.action || null,
         );
       }
     } catch (error) {
@@ -1346,9 +1352,24 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     const fileMap = files[currentChecklistNumber()];
     const file = fileMap.file;
     const urls = await processFileToSend(file.file);
+
+    const fileProcessed = await extractSHA256AndCheckDocumentHash(fileMap);
+
+    if (fileProcessed != null) {
+      let processedDocumentJson = JSON.parse(fileProcessed);
+      processedDocumentJson = sanitizeJson(processedDocumentJson);
+      await processCriticalAnalysisUpdate(processedDocumentJson, true);
+    } else {
+      await processNewFileData(file, files, urls);
+    }
+
+    scrollToBottom();
+  };
+
+  async function processNewFileData(file: any, files: any[], urls: Partial<FileUpload>[]) {
     const textContent = await getTextContent(file.file);
 
-    setMessages((prevMessages) => [...prevMessages, { message: `${file.name}`, type: 'userMessage', fileUploads: urls as Partial<FileUpload>[] }]);
+    setMessages((prevMessages) => [...prevMessages, { message: `${file.name}`, type: 'userMessage', fileUploads: urls }]);
 
     const promptCriticalAnalysis = `VERIFICAR DADOS ANALISE CRITICA`;
     const dataFoundCriticalAnalysis = await sendBackgroundMessage(promptCriticalAnalysis, urls as any[]);
@@ -1357,9 +1378,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       extractAndSaveDocumentData(file, textContent, dataFoundCriticalAnalysis);
     }
     await processCriticalAnalysisUpdate(dataFoundCriticalAnalysis);
-
-    scrollToBottom();
-  };
+  }
 
   return (
     <>

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1000,6 +1000,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   };
 
   const sendBackgroundMessage = async (value: string, urls: any[]) => {
+    console.log('passou aqui', value);
     const body: IncomingInput = {
       question: value,
       chatId: chatId(),
@@ -1074,14 +1075,14 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     }
   };
 
-  const extractDocumentData = async (fileMap: any, textContent: any) => {
+  const extractDocumentData = async (fileMap: any, textContent: any, agentResult?: any) => {
     const pdfBase64 = await pdfToBase64(fileMap.file.file);
     return {
       file_name: fileMap.file.file.name,
       file_extension: fileMap.file.file.type,
       hash: pdfBase64,
-      checklist_result: fileMap.filledChecklist,
-      extraction_result: fileMap.content,
+      checklist_result: fileMap.filledChecklist || agentResult,
+      extraction_result: fileMap.content || agentResult,
       pdf_to_text: textContent,
       checklist_type: fileMap.type,
     };
@@ -1096,8 +1097,8 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     }
   };
 
-  const extractAndSaveDocumentData = async (fileMap: any, textContent: any) => {
-    const documentData = await extractDocumentData(fileMap, textContent);
+  const extractAndSaveDocumentData = async (fileMap: any, textContent: any, agentResult?: any) => {
+    const documentData = await extractDocumentData(fileMap, textContent, agentResult?.text);
     await saveDocumentData(documentData);
   };
 
@@ -1315,12 +1316,16 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     const fileMap = files[currentChecklistNumber()];
     const file = fileMap.file;
     const urls = await processFileToSend(file.file);
+    const textContent = await getTextContent(file.file);
 
     setMessages((prevMessages) => [...prevMessages, { message: `${file.name}`, type: 'userMessage', fileUploads: urls as Partial<FileUpload>[] }]);
 
     const promptCriticalAnalysis = `VERIFICAR DADOS ANALISE CRITICA`;
     const dataFoundCriticalAnalysis = await sendBackgroundMessage(promptCriticalAnalysis, urls as any[]);
 
+    for (const file of files) {
+      extractAndSaveDocumentData(file, textContent, dataFoundCriticalAnalysis);
+    }
     await processCriticalAnalysisUpdate(dataFoundCriticalAnalysis);
 
     scrollToBottom();

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1127,7 +1127,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
         if (!Object.keys(jsonData).includes('checklist')) {
           throw new Error(messageUtils.CHECKLIST_NOT_FOUND_IN_RESPONSE_ERROR);
         }
-        documentService.extractAndSaveDocumentData(fileMap, textContent, props.flow);
+        documentService.saveExtractedDataToDatabase(fileMap, textContent, props.flow);
         structureAndSaveMessages(jsonData, fileMap, resultFromBackgroundMessage);
 
         break;
@@ -1249,7 +1249,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     setUploading(false);
     setMessages((prevMessages) => [...prevMessages, { message: `${file.name}`, type: 'userMessage', fileUploads: urls }]);
 
-    const fileProcessed = await documentService.extractSHA256AndCheckDocumentHash(fileMap, props.flow);
+    const fileProcessed = await documentService.checkDocumentForAlreadyProcessedData(fileMap, props.flow);
 
     if (fileProcessed != null) {
       let processedDocumentJson = JSON.parse(fileProcessed);
@@ -1306,7 +1306,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     const file = fileMap.file;
     const urls = await processFileToSend(file.file);
 
-    const fileProcessed = await documentService.extractSHA256AndCheckDocumentHash(fileMap, props.flow);
+    const fileProcessed = await documentService.checkDocumentForAlreadyProcessedData(fileMap, props.flow);
 
     if (fileProcessed != null) {
       let processedDocumentJson = JSON.parse(fileProcessed);
@@ -1328,7 +1328,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     const dataFoundCriticalAnalysis = await sendBackgroundMessage(promptCriticalAnalysis, urls as any[]);
 
     for (const file of files) {
-      documentService.extractAndSaveDocumentData(file, textContent, props.flow, dataFoundCriticalAnalysis);
+      documentService.saveExtractedDataToDatabase(file, textContent, props.flow, dataFoundCriticalAnalysis);
     }
     await processCriticalAnalysisUpdate(dataFoundCriticalAnalysis);
   }

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1090,6 +1090,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       extraction_result: fileMap.content || agentResult,
       pdf_to_text: textContent,
       checklist_type: fileMap.type,
+      agent_flow: props.flow,
     };
   };
 
@@ -1110,7 +1111,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   const checkDocumentHash = async (pdfSHA256: any): Promise<any> => {
     const documentService = new DocumentsDBService();
     try {
-      const result = await documentService.isHashInDatabase(pdfSHA256);
+      const result = await documentService.isHashInDatabase(pdfSHA256, props.flow);
       return result;
     } catch (error) {
       console.error('Error checking hash on database:', error);

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -25,7 +25,7 @@ import { UploadFile } from '@solid-primitives/upload';
 import { NextChecklistButton } from '@/components/buttons/NextChecklistButton';
 import { isImage } from '@/utils/isImage';
 import { FileMapping } from '@/utils/fileUtils';
-import { convertPdfToMultipleImages, pdfToText, pdfToSHA256 } from '@/utils/pdfUtils';
+import { convertPdfToMultipleImages, pdfToText } from '@/utils/pdfUtils';
 import {
   defaultChecklist,
   conferencesDefault,

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -151,6 +151,7 @@ export type LeadsConfig = {
 const defaultWelcomeMessage = 'Hi there! How can I help?';
 const defaultBackgroundColor = '#ffffff';
 const defaultTextColor = '#303235';
+const documentService = new DocumentsDBService();
 
 export const Bot = (botProps: BotProps & { class?: string }) => {
   // set a default value for showTitle if not set and merge with other props
@@ -1078,51 +1079,6 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     }
   };
 
-  const extractDocumentData = async (fileMap: any, textContent: any, agentResult?: any) => {
-    const pdfSHA256 = await pdfToSHA256(fileMap.file.file);
-    return {
-      file_name: fileMap.file.file.name,
-      file_extension: fileMap.file.file.type,
-      hash: pdfSHA256,
-      checklist_result: fileMap.filledChecklist || agentResult,
-      extraction_result: fileMap.content || agentResult,
-      pdf_to_text: textContent,
-      checklist_type: fileMap.type,
-      agent_flow: props.flow,
-    };
-  };
-
-  const saveDocumentData = async (documentData: any) => {
-    const documentService = new DocumentsDBService();
-    try {
-      await documentService.saveDocument(documentData);
-    } catch (error) {
-      console.error('Error saving to the database:', error);
-    }
-  };
-
-  const extractAndSaveDocumentData = async (fileMap: any, textContent: any, agentResult?: any) => {
-    const documentData = await extractDocumentData(fileMap, textContent, agentResult?.text);
-    await saveDocumentData(documentData);
-  };
-
-  const checkDocumentHash = async (pdfSHA256: any): Promise<any> => {
-    const documentService = new DocumentsDBService();
-    try {
-      const result = await documentService.isHashInDatabase(pdfSHA256, props.flow);
-      return result;
-    } catch (error) {
-      console.error('Error checking hash on database:', error);
-      return null;
-    }
-  };
-
-  const extractSHA256AndCheckDocumentHash = async (fileMap: any): Promise<any> => {
-    const pdfSHA256 = await pdfToSHA256(fileMap.file.file);
-    const fileProcessed = await checkDocumentHash(pdfSHA256);
-    return fileProcessed?.checklist_result;
-  };
-
   const processFileToSend = async (file: File) => {
     let imagesList: File[] = [];
 
@@ -1171,8 +1127,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
         if (!Object.keys(jsonData).includes('checklist')) {
           throw new Error(messageUtils.CHECKLIST_NOT_FOUND_IN_RESPONSE_ERROR);
         }
-
-        extractAndSaveDocumentData(fileMap, textContent);
+        documentService.extractAndSaveDocumentData(fileMap, textContent, props.flow);
         structureAndSaveMessages(jsonData, fileMap, resultFromBackgroundMessage);
 
         break;
@@ -1295,7 +1250,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     setUploading(false);
     setMessages((prevMessages) => [...prevMessages, { message: `${file.name}`, type: 'userMessage', fileUploads: urls }]);
 
-    const fileProcessed = await extractSHA256AndCheckDocumentHash(fileMap);
+    const fileProcessed = await documentService.extractSHA256AndCheckDocumentHash(fileMap, props.flow);
 
     if (fileProcessed != null) {
       let processedDocumentJson = JSON.parse(fileProcessed);
@@ -1352,7 +1307,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     const file = fileMap.file;
     const urls = await processFileToSend(file.file);
 
-    const fileProcessed = await extractSHA256AndCheckDocumentHash(fileMap);
+    const fileProcessed = await documentService.extractSHA256AndCheckDocumentHash(fileMap, props.flow);
 
     if (fileProcessed != null) {
       let processedDocumentJson = JSON.parse(fileProcessed);
@@ -1374,7 +1329,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     const dataFoundCriticalAnalysis = await sendBackgroundMessage(promptCriticalAnalysis, urls as any[]);
 
     for (const file of files) {
-      extractAndSaveDocumentData(file, textContent, dataFoundCriticalAnalysis);
+      documentService.extractAndSaveDocumentData(file, textContent, props.flow, dataFoundCriticalAnalysis);
     }
     await processCriticalAnalysisUpdate(dataFoundCriticalAnalysis);
   }

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -456,10 +456,8 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
 
   const processCriticalAnalysisUpdate = async (jsonCriticalAnalysisUpdate: any, processedFile?: boolean) => {
     try {
-      let jsonDataCriticalAnalysis;
-      if (processedFile) {
-        jsonDataCriticalAnalysis = jsonCriticalAnalysisUpdate;
-      } else {
+      let jsonDataCriticalAnalysis = jsonCriticalAnalysisUpdate;
+      if (!processedFile) {
         jsonDataCriticalAnalysis = JSON.parse(jsonCriticalAnalysisUpdate.text);
       }
 

--- a/flowise-embed/src/constants.ts
+++ b/flowise-embed/src/constants.ts
@@ -23,7 +23,7 @@ export const constants = {
   n8nSixthStep: '50b6723d-7cff-4ecf-852e-f693efd9d95f',
   n8nSeventhStep: '916a955c-467e-4830-9d95-3bb3fc976698',
   n8nFlowSendDataToSupabase: '83faf03f-f684-4b7c-9c07-10f0fb237a26',
-  n8nFlowGetDataToSupabase: 'cce1b9da-cf8e-46cb-b36a-9028c13f1a4e',
+  n8nFlowGetDataFromSupabase: 'cce1b9da-cf8e-46cb-b36a-9028c13f1a4e',
 };
 
 export const defaultMenuProps: MenuProps = {

--- a/flowise-embed/src/constants.ts
+++ b/flowise-embed/src/constants.ts
@@ -22,6 +22,8 @@ export const constants = {
   n8nFifthStep: 'e05fca0c-20fb-42ed-a923-a627d9ae7f13',
   n8nSixthStep: '50b6723d-7cff-4ecf-852e-f693efd9d95f',
   n8nSeventhStep: '916a955c-467e-4830-9d95-3bb3fc976698',
+  n8nFlowSendDataToSupabase: '83faf03f-f684-4b7c-9c07-10f0fb237a26',
+  n8nFlowGetDataToSupabase: 'cce1b9da-cf8e-46cb-b36a-9028c13f1a4e',
 };
 
 export const defaultMenuProps: MenuProps = {

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -1,0 +1,95 @@
+import { constants } from '@/constants';
+
+interface DocumentData {
+  file_name: string;
+  file_extension: string;
+  hash: string;
+  checklist_result?: any;
+  extraction_result?: any;
+  pdf_to_text?: string;
+  images?: string[];
+}
+
+export default class DocumentDatabaseService {
+  private apiEndpoint: string;
+  private storageEndpoint: string;
+  public documentData: DocumentData & { version: number };
+
+  constructor(documentData: DocumentData) {
+    this.apiEndpoint = `${constants.supabaseApiEndpoint}/Documents`;
+    this.storageEndpoint = `${constants.supabaseStorageEndpoint}`;
+
+    const versionMatch = documentData.file_name.match(/v(\d+)/);
+    const version = versionMatch ? parseInt(versionMatch[1], 10) : 1;
+
+    this.documentData = { ...documentData, version };
+  }
+
+  public async saveDocument(): Promise<void> {
+    try {
+      //   await this.saveImagesToBucket();
+      await this.sendToDatabase(this.documentData);
+    } catch (error) {
+      console.error('Erro ao salvar documento:', error);
+    }
+  }
+
+  private async sendToDatabase(document: DocumentData & { version: number }): Promise<void> {
+    try {
+      const response = await fetch(this.apiEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: constants.supabaseApiKey,
+          Authorization: `Bearer ${constants.supabaseApiKey}`,
+        },
+        body: JSON.stringify(document),
+      });
+
+      if (!response.ok) {
+        throw new Error('Erro ao enviar documento ao banco de dados.');
+      }
+    } catch (error) {
+      console.error('Erro ao salvar no banco de dados:', error);
+    }
+  }
+
+  //   // Método para salvar as imagens geradas no Supabase Storage Bucket
+  //   private async saveImagesToBucket(): Promise<void> {
+  //     if (!this.documentData.images || this.documentData.images.length === 0) {
+  //       console.log('Nenhuma imagem para salvar.');
+  //       return;
+  //     }
+
+  //     const savedImageUrls: string[] = [];
+  //     for (let i = 0; i < this.documentData.images.length; i++) {
+  //       const image = this.documentData.images[i];
+  //       const fileName = `${this.documentData.file_name}-page-${i + 1}.png`;
+
+  //       try {
+  //         const response = await fetch(`${this.storageEndpoint}/upload`, {
+  //           method: 'POST',
+  //           headers: {
+  //             apikey: constants.supabaseApiKey,
+  //             Authorization: `Bearer ${constants.supabaseApiKey}`,
+  //             'Content-Type': 'application/octet-stream', // para enviar a imagem em binário
+  //           },
+  //           body: image, // Aqui, você pode enviar o Blob ou base64 da imagem
+  //         });
+
+  //         if (response.ok) {
+  //           const { Key } = await response.json();
+  //           const imageUrl = `${this.storageEndpoint}/public/${Key}`;
+  //           savedImageUrls.push(imageUrl);
+  //         } else {
+  //           throw new Error('Erro ao salvar imagem no bucket.');
+  //         }
+  //       } catch (error) {
+  //         console.error('Erro ao salvar imagem no bucket:', error);
+  //       }
+  //     }
+
+  //     // Atualiza o documento com as URLs das imagens salvas
+  //     this.documentData.images = savedImageUrls;
+  //   }
+}

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -8,36 +8,12 @@ interface DocumentData {
   extraction_result?: any;
   pdf_to_text?: string;
   checklist_type?: string;
-  images?: string[];
 }
 
-export default class DocumentDatabaseService {
-  private apiEndpoint: string;
-  private storageEndpoint: string;
-  public documentData: DocumentData & { version: number };
-
-  constructor(documentData: DocumentData) {
-    this.apiEndpoint = `${constants.supabaseApiEndpoint}rest/v1/Documents`;
-    this.storageEndpoint = `${constants.supabaseApiEndpoint}storage/v1/object/Interseas/`;
-
-    const versionMatch = documentData.file_name.match(/v(\d+)/i);
-    const version = versionMatch ? parseInt(versionMatch[1]) : 0;
-    const fileNameWithoutVersion = documentData.file_name.replace(/v\d+/i, '').trim();
-
-    this.documentData = { ...documentData, file_name: fileNameWithoutVersion, version };
-  }
-
-  public async saveDocument(): Promise<void> {
+class DocumentsDBService {
+  private async sendToDatabase(document: DocumentData): Promise<void> {
     try {
-      await this.sendToDatabase(this.documentData);
-    } catch (error) {
-      console.error('Erro ao salvar documento:', error);
-    }
-  }
-
-  private async sendToDatabase(document: DocumentData & { version: number }): Promise<void> {
-    try {
-      const response = await fetch(this.apiEndpoint, {
+      const response = await fetch(constants.n8nDomain + '/webhook/' + constants.n8nFlowSendDataToSupabase, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -54,4 +30,10 @@ export default class DocumentDatabaseService {
       console.error('Erro ao salvar no banco de dados:', error);
     }
   }
+
+  public async saveDocument(documentData: DocumentData): Promise<void> {
+    await this.sendToDatabase(documentData);
+  }
 }
+
+export default DocumentsDBService;

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -21,7 +21,7 @@ export default class DocumentDatabaseService {
     this.storageEndpoint = `${constants.supabaseApiEndpoint}storage/v1/object/Interseas/`;
 
     const versionMatch = documentData.file_name.match(/v(\d+)/i);
-    const version = versionMatch ? parseInt(versionMatch[1]) : 0; // Remove o 10 e usa somente parseInt sem base 10
+    const version = versionMatch ? parseInt(versionMatch[1]) : 0;
     const fileNameWithoutVersion = documentData.file_name.replace(/v\d+/i, '').trim();
 
     this.documentData = { ...documentData, file_name: fileNameWithoutVersion, version };

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -31,8 +31,6 @@ class DocumentsDBService {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          apikey: constants.supabaseApiKey,
-          Authorization: `Bearer ${constants.supabaseApiKey}`,
         },
         body: JSON.stringify({ hash }),
       });

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -1,4 +1,5 @@
 import { constants } from '@/constants';
+import { Flow } from '@/features/bubble/types';
 
 interface DocumentData {
   file_name?: string;
@@ -8,6 +9,7 @@ interface DocumentData {
   extraction_result?: any;
   pdf_to_text?: string;
   checklist_type?: string;
+  agent_flow: string;
 }
 
 class DocumentsDBService {
@@ -25,14 +27,14 @@ class DocumentsDBService {
     }
   }
 
-  private async checkHashInDatabase(hash: any): Promise<boolean> {
+  private async checkHashInDatabase(hash: any, agent_flow: Flow): Promise<boolean> {
     try {
       const response = await fetch(constants.n8nDomain + '/webhook/' + constants.n8nFlowGetDataToSupabase, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ hash }),
+        body: JSON.stringify({ hash, agent_flow }),
       });
 
       const data = await response.json();
@@ -47,8 +49,10 @@ class DocumentsDBService {
     await this.sendDataToN8n(documentData);
   }
 
-  public async isHashInDatabase(hash: string): Promise<boolean> {
-    return await this.checkHashInDatabase(hash);
+  public async isHashInDatabase(hash: string, agent_flow: Flow): Promise<boolean> {
+    console.log('Checking hash in the database:', hash);
+    console.log('Checking hash in the agent_flow:', agent_flow);
+    return await this.checkHashInDatabase(hash, agent_flow);
   }
 }
 

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -28,7 +28,7 @@ class DocumentsDBService {
     }
   }
 
-  private async checkHashInDatabase(hash: any, agent_flow: Flow): Promise<boolean> {
+  private async getDocumentFromDBByHash(hash: any, agent_flow: Flow): Promise<any> {
     try {
       const response = await fetch(constants.n8nDomain + '/webhook/' + constants.n8nFlowGetDataToSupabase, {
         method: 'POST',
@@ -41,8 +41,7 @@ class DocumentsDBService {
       const data = await response.json();
       return data;
     } catch (error) {
-      console.error('Error checking hash in the database:', error);
-      return false;
+      throw new Error(`Error checking hash in the database:', ${error}`);
     }
   }
 
@@ -51,7 +50,7 @@ class DocumentsDBService {
   }
 
   public async isHashInDatabase(hash: string, agentFlow: Flow): Promise<boolean> {
-    return await this.checkHashInDatabase(hash, agentFlow);
+    return await this.getDocumentFromDBByHash(hash, agentFlow);
   }
 
   public async extractDocumentData(fileMap: any, textContent: any, agentFlow: Flow, agentResult?: any): Promise<DocumentData> {

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -11,7 +11,7 @@ interface DocumentData {
 }
 
 class DocumentsDBService {
-  private async sendToDatabase(document: DocumentData): Promise<void> {
+  private async sendDataToN8n(document: DocumentData): Promise<void> {
     try {
       const response = await fetch(constants.n8nDomain + '/webhook/' + constants.n8nFlowSendDataToSupabase, {
         method: 'POST',
@@ -26,7 +26,7 @@ class DocumentsDBService {
   }
 
   public async saveDocument(documentData: DocumentData): Promise<void> {
-    await this.sendToDatabase(documentData);
+    await this.sendDataToN8n(documentData);
   }
 }
 

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -3,7 +3,7 @@ import { constants } from '@/constants';
 interface DocumentData {
   file_name: string;
   file_extension: string;
-  hash: string;
+  hash: any;
   checklist_result?: any;
   extraction_result?: any;
   pdf_to_text?: string;
@@ -17,17 +17,15 @@ class DocumentsDBService {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          apikey: constants.supabaseApiKey,
-          Authorization: `Bearer ${constants.supabaseApiKey}`,
         },
         body: JSON.stringify(document),
       });
 
       if (!response.ok) {
-        throw new Error('Erro ao enviar documento ao banco de dados.');
+        throw new Error('Error sending document to the database.');
       }
     } catch (error) {
-      console.error('Erro ao salvar no banco de dados:', error);
+      console.error('Error saving to the database:', error);
     }
   }
 

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -20,10 +20,6 @@ class DocumentsDBService {
         },
         body: JSON.stringify(document),
       });
-
-      if (!response.ok) {
-        throw new Error('Error sending document to the database.');
-      }
     } catch (error) {
       console.error('Error saving to the database:', error);
     }

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -30,7 +30,7 @@ class DocumentsDBService {
 
   private async getDocumentFromDBByHash(hash: any, agent_flow: Flow): Promise<any> {
     try {
-      const response = await fetch(constants.n8nDomain + '/webhook/' + constants.n8nFlowGetDataToSupabase, {
+      const response = await fetch(constants.n8nDomain + '/webhook/' + constants.n8nFlowGetDataFromSupabase, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -77,7 +77,7 @@ class DocumentsDBService {
     }
   }
 
-  public async extractAndSaveDocumentData(fileMap: any, textContent: any, agentFlow: Flow, agentResult?: any): Promise<void> {
+  public async saveExtractedDataToDatabase(fileMap: any, textContent: any, agentFlow: Flow, agentResult?: any): Promise<void> {
     const documentData = await this.extractDocumentData(fileMap, textContent, agentFlow, agentResult?.text);
     await this.saveDocumentData(documentData);
   }
@@ -92,7 +92,7 @@ class DocumentsDBService {
     }
   }
 
-  public async extractSHA256AndCheckDocumentHash(fileMap: any, agentFlow: Flow): Promise<any> {
+  public async checkDocumentForAlreadyProcessedData(fileMap: any, agentFlow: Flow): Promise<any> {
     const hashPdf = await pdfToHash(fileMap.file.file);
     const fileProcessed = await this.checkDocumentHash(hashPdf, agentFlow);
     return fileProcessed?.checklist_result;

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -16,7 +16,7 @@ interface DocumentData {
 class DocumentsDBService {
   private async sendDataToN8n(document: DocumentData): Promise<void> {
     try {
-      const response = await fetch(constants.n8nDomain + '/webhook/' + constants.n8nFlowSendDataToSupabase, {
+      await fetch(constants.n8nDomain + '/webhook/' + constants.n8nFlowSendDataToSupabase, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -41,7 +41,7 @@ class DocumentsDBService {
       const data = await response.json();
       return data;
     } catch (error) {
-      throw new Error(`Error checking hash in the database:', ${error}`);
+      throw new Error(`Error find document on DB:', ${error}`);
     }
   }
 
@@ -55,7 +55,6 @@ class DocumentsDBService {
 
   public async extractDocumentData(fileMap: any, textContent: any, agentFlow: Flow, agentResult?: any): Promise<DocumentData> {
     const hashPdf = await pdfToHash(fileMap.file.file);
-    console.log('agentFlow:', agentFlow);
     return {
       file_name: fileMap.file.file.name,
       file_extension: fileMap.file.file.type,
@@ -81,9 +80,9 @@ class DocumentsDBService {
     await this.saveDocumentData(documentData);
   }
 
-  public async checkDocumentHash(pdfSHA256: any, agentFlow: Flow): Promise<any> {
+  public async checkDocumentHash(hashPdf: any, agentFlow: Flow): Promise<any> {
     try {
-      const result = await this.isHashInDatabase(pdfSHA256, agentFlow);
+      const result = await this.isHashInDatabase(hashPdf, agentFlow);
       return result;
     } catch (error) {
       console.error('Error checking hash on database:', error);

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -50,8 +50,6 @@ class DocumentsDBService {
   }
 
   public async isHashInDatabase(hash: string, agent_flow: Flow): Promise<boolean> {
-    console.log('Checking hash in the database:', hash);
-    console.log('Checking hash in the agent_flow:', agent_flow);
     return await this.checkHashInDatabase(hash, agent_flow);
   }
 }

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -1,9 +1,9 @@
 import { constants } from '@/constants';
 
 interface DocumentData {
-  file_name: string;
-  file_extension: string;
-  hash: any;
+  file_name?: string;
+  file_extension?: string;
+  hash: string;
   checklist_result?: any;
   extraction_result?: any;
   pdf_to_text?: string;
@@ -25,8 +25,33 @@ class DocumentsDBService {
     }
   }
 
+  private async checkHashInDatabase(hash: any): Promise<boolean> {
+    try {
+      const response = await fetch(constants.n8nDomain + '/webhook/' + constants.n8nFlowGetDataToSupabase, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: constants.supabaseApiKey,
+          Authorization: `Bearer ${constants.supabaseApiKey}`,
+        },
+        body: JSON.stringify({ hash }),
+      });
+
+      const data = await response.json();
+      console.log('data', data);
+      return data;
+    } catch (error) {
+      console.error('Error checking hash in the database:', error);
+      return false;
+    }
+  }
+
   public async saveDocument(documentData: DocumentData): Promise<void> {
     await this.sendDataToN8n(documentData);
+  }
+
+  public async isHashInDatabase(hash: string): Promise<boolean> {
+    return await this.checkHashInDatabase(hash);
   }
 }
 

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -36,7 +36,6 @@ class DocumentsDBService {
       });
 
       const data = await response.json();
-      console.log('data', data);
       return data;
     } catch (error) {
       console.error('Error checking hash in the database:', error);

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -1,5 +1,6 @@
 import { constants } from '@/constants';
 import { Flow } from '@/features/bubble/types';
+import { pdfToSHA256 } from '@/utils/pdfUtils';
 
 interface DocumentData {
   file_name?: string;
@@ -49,8 +50,53 @@ class DocumentsDBService {
     await this.sendDataToN8n(documentData);
   }
 
-  public async isHashInDatabase(hash: string, agent_flow: Flow): Promise<boolean> {
-    return await this.checkHashInDatabase(hash, agent_flow);
+  public async isHashInDatabase(hash: string, agentFlow: Flow): Promise<boolean> {
+    return await this.checkHashInDatabase(hash, agentFlow);
+  }
+
+  public async extractDocumentData(fileMap: any, textContent: any, agentFlow: Flow, agentResult?: any): Promise<DocumentData> {
+    const pdfSHA256 = await pdfToSHA256(fileMap.file.file);
+    console.log('agentFlow:', agentFlow);
+    return {
+      file_name: fileMap.file.file.name,
+      file_extension: fileMap.file.file.type,
+      hash: pdfSHA256,
+      checklist_result: fileMap.filledChecklist || agentResult,
+      extraction_result: fileMap.content || agentResult,
+      pdf_to_text: textContent,
+      checklist_type: fileMap.type,
+      agent_flow: agentFlow,
+    };
+  }
+
+  public async saveDocumentData(documentData: DocumentData): Promise<void> {
+    try {
+      await this.saveDocument(documentData);
+    } catch (error) {
+      console.error('Error saving to the database:', error);
+    }
+  }
+
+  public async extractAndSaveDocumentData(fileMap: any, textContent: any, agentFlow: Flow, agentResult?: any): Promise<void> {
+    const documentData = await this.extractDocumentData(fileMap, textContent, agentFlow, agentResult?.text);
+    await this.saveDocumentData(documentData);
+  }
+
+  public async checkDocumentHash(pdfSHA256: any, agentFlow: Flow): Promise<any> {
+    try {
+      const result = await this.isHashInDatabase(pdfSHA256, agentFlow);
+      return result;
+    } catch (error) {
+      console.error('Error checking hash on database:', error);
+      return null;
+    }
+  }
+
+  public async extractSHA256AndCheckDocumentHash(fileMap: any, agentFlow: Flow): Promise<any> {
+    const pdfSHA256 = await pdfToSHA256(fileMap.file.file);
+    console.log('fileMap.flow:', agentFlow);
+    const fileProcessed = await this.checkDocumentHash(pdfSHA256, agentFlow);
+    return fileProcessed?.checklist_result;
   }
 }
 

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -1,6 +1,6 @@
 import { constants } from '@/constants';
 import { Flow } from '@/features/bubble/types';
-import { pdfToSHA256 } from '@/utils/pdfUtils';
+import { pdfToHash } from '@/utils/pdfUtils';
 
 interface DocumentData {
   file_name?: string;
@@ -55,12 +55,12 @@ class DocumentsDBService {
   }
 
   public async extractDocumentData(fileMap: any, textContent: any, agentFlow: Flow, agentResult?: any): Promise<DocumentData> {
-    const pdfSHA256 = await pdfToSHA256(fileMap.file.file);
+    const hashPdf = await pdfToHash(fileMap.file.file);
     console.log('agentFlow:', agentFlow);
     return {
       file_name: fileMap.file.file.name,
       file_extension: fileMap.file.file.type,
-      hash: pdfSHA256,
+      hash: hashPdf,
       checklist_result: fileMap.filledChecklist || agentResult,
       extraction_result: fileMap.content || agentResult,
       pdf_to_text: textContent,
@@ -93,9 +93,8 @@ class DocumentsDBService {
   }
 
   public async extractSHA256AndCheckDocumentHash(fileMap: any, agentFlow: Flow): Promise<any> {
-    const pdfSHA256 = await pdfToSHA256(fileMap.file.file);
-    console.log('fileMap.flow:', agentFlow);
-    const fileProcessed = await this.checkDocumentHash(pdfSHA256, agentFlow);
+    const hashPdf = await pdfToHash(fileMap.file.file);
+    const fileProcessed = await this.checkDocumentHash(hashPdf, agentFlow);
     return fileProcessed?.checklist_result;
   }
 }

--- a/flowise-embed/src/utils/pdfUtils.ts
+++ b/flowise-embed/src/utils/pdfUtils.ts
@@ -133,6 +133,18 @@ export const pdfToText = async (blob: Blob): Promise<string> => {
     return extractTextLocally(file);
   }
 };
+
+export const pdfToBase64 = async (blob: Blob): Promise<string> => {
+  try {
+    const base64FromBlob = await convertToBase64(blob);
+    return base64FromBlob;
+  } catch (error) {
+    const file = blobToFile(blob, 'convertedFile.pdf');
+    const base64FromFile = await convertToBase64(file);
+    return base64FromFile;
+  }
+};
+
 interface IPageTextContent {
   items: { str: string }[];
 }
@@ -160,4 +172,16 @@ const extractTextLocally = async (file: File): Promise<string> => {
     console.error('Error during local text extraction:', error);
     throw error;
   }
+};
+
+const convertToBase64 = (input: Blob | File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const base64data = reader.result?.toString().split(',')[1];
+      resolve(base64data || '');
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(input);
+  });
 };

--- a/flowise-embed/src/utils/pdfUtils.ts
+++ b/flowise-embed/src/utils/pdfUtils.ts
@@ -10,6 +10,10 @@ declare global {
 
 const pdfjsLib = window.pdfjsLib;
 
+interface TextItem {
+  str: string;
+}
+
 const readFileData = (file: File) => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();

--- a/flowise-embed/src/utils/pdfUtils.ts
+++ b/flowise-embed/src/utils/pdfUtils.ts
@@ -134,15 +134,31 @@ export const pdfToText = async (blob: Blob): Promise<string> => {
   }
 };
 
-export const pdfToBase64 = async (blob: Blob): Promise<string> => {
-  try {
-    const base64FromBlob = await convertToBase64(blob);
-    return base64FromBlob;
-  } catch (error) {
-    const file = blobToFile(blob, 'convertedFile.pdf');
-    const base64FromFile = await convertToBase64(file);
-    return base64FromFile;
-  }
+export const pdfToSHA256 = async (blob: Blob): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.readAsArrayBuffer(blob);
+
+    reader.onloadend = async () => {
+      try {
+        const arrayBuffer = reader.result as ArrayBuffer;
+        const hashBuffer = await crypto.subtle.digest('SHA-256', arrayBuffer);
+
+        // Convertendo o ArrayBuffer para uma string hexadecimal
+        const hashArray = Array.from(new Uint8Array(hashBuffer));
+        const hashHex = hashArray.map((byte) => byte.toString(16).padStart(2, '0')).join('');
+
+        resolve(hashHex);
+      } catch (error) {
+        reject(error);
+      }
+    };
+
+    reader.onerror = () => {
+      reject(reader.error);
+    };
+  });
 };
 
 interface IPageTextContent {

--- a/flowise-embed/src/utils/pdfUtils.ts
+++ b/flowise-embed/src/utils/pdfUtils.ts
@@ -130,16 +130,17 @@ export const pdfToText = async (blob: Blob): Promise<string> => {
   }
 };
 
-export const pdfToSHA256 = async (blob: Blob): Promise<string> => {
+export const pdfToHash = async (blob: Blob): Promise<string> => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
+    const hashAlgorithm = 'SHA-256';
 
     reader.readAsArrayBuffer(blob);
 
     reader.onloadend = async () => {
       try {
         const arrayBuffer = reader.result as ArrayBuffer;
-        const hashBuffer = await crypto.subtle.digest('SHA-256', arrayBuffer);
+        const hashBuffer = await crypto.subtle.digest(hashAlgorithm, arrayBuffer);
         const hashArray = Array.from(new Uint8Array(hashBuffer));
         const hashHex = hashArray.map((byte) => byte.toString(16).padStart(2, '0')).join('');
 

--- a/flowise-embed/src/utils/pdfUtils.ts
+++ b/flowise-embed/src/utils/pdfUtils.ts
@@ -10,10 +10,6 @@ declare global {
 
 const pdfjsLib = window.pdfjsLib;
 
-interface TextItem {
-  str: string;
-}
-
 const readFileData = (file: File) => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -144,8 +140,6 @@ export const pdfToSHA256 = async (blob: Blob): Promise<string> => {
       try {
         const arrayBuffer = reader.result as ArrayBuffer;
         const hashBuffer = await crypto.subtle.digest('SHA-256', arrayBuffer);
-
-        // Convertendo o ArrayBuffer para uma string hexadecimal
         const hashArray = Array.from(new Uint8Array(hashBuffer));
         const hashHex = hashArray.map((byte) => byte.toString(16).padStart(2, '0')).join('');
 
@@ -188,16 +182,4 @@ const extractTextLocally = async (file: File): Promise<string> => {
     console.error('Error during local text extraction:', error);
     throw error;
   }
-};
-
-const convertToBase64 = (input: Blob | File): Promise<string> => {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      const base64data = reader.result?.toString().split(',')[1];
-      resolve(base64data || '');
-    };
-    reader.onerror = reject;
-    reader.readAsDataURL(input);
-  });
 };


### PR DESCRIPTION
Preparar ambos os comportamentos:

Ao processar um novo documento, salvar seu nome, seu hash, seu tipo e seu resultado, da extração e validação, associados ao chat ao qual pertence,  no banco de dados.

Ao receber um documento, verificar o hash e se ele já foi processado anteriormente no chat atual (seu hash está no banco) e utilizar essas informações ao invés de re-processá-lo, caso haja.