### PR TITLE
[ACI-66] - [Compliance] Adicionar justificativa às conferências na extração dos documentos

### DIFF
--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1160,17 +1160,16 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
             }
 
             const spacedText = (text: string) => `<div style="padding-left: 20px; margin-bottom: 10px;">${text}</div>`;
-            const hasValue = ![customBooleanValues.NOT_FOUND.toString(), null].includes(value);
-            const isMachineOrEquipment = value && value.includes(customBooleanValues.FALSE_WITH_JUSTIFICATION.toString());
-            const equipmentValue = isMachineOrEquipment ? value : 'Não identificado';
+            const isValidValue = ![customBooleanValues.NOT_FOUND.toString(), null].includes(value);
+            const hasJustificationNotFound = value && value.includes(customBooleanValues.FALSE_WITH_JUSTIFICATION.toString());
+            const defaultNotFoundMessage = hasJustificationNotFound ? value : 'Não identificado';
+            const signatureKey = 'Assinatura';
+            const messageNotFoundSignature = 'A assinatura não foi identificada, por favor verifique manualmente!';
+            const notFoundMessage = key === signatureKey ? messageNotFoundSignature : defaultNotFoundMessage;
 
-            let checklistItem = `<input type="checkbox" ${hasValue && !isMachineOrEquipment ? 'checked' : ''} disabled> <b>${key}</b>:<br>`;
+            let checklistItem = `<input type="checkbox" ${isValidValue && !hasJustificationNotFound ? 'checked' : ''} disabled> <b>${key}</b>:<br>`;
             checklistItem += spacedText(
-              hasValue && !isMachineOrEquipment
-                ? value
-                : `<span style="color: ${colorTheme.errorColor};">${
-                    key === 'Assinatura' ? 'A assinatura não foi identificada, por favor verifique manualmente!' : equipmentValue
-                  }</span>`,
+              isValidValue && !hasJustificationNotFound ? value : `<span style="color: ${colorTheme.errorColor};">${notFoundMessage}</span>`,
             );
             return checklistItem;
           };

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1160,17 +1160,27 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
             }
 
             const spacedText = (text: string) => `<div style="padding-left: 20px; margin-bottom: 10px;">${text}</div>`;
+            const getMessage = (key: string, value: any, validValue: boolean, justificationNotFound: boolean) => {
+              if (validValue && !justificationNotFound) {
+                return spacedText(value);
+              } else {
+                const defaultNotFoundMessage = justificationNotFound ? value : 'Não identificado';
+                const signatureKey = 'Assinatura';
+                const messageNotFoundSignature = 'A assinatura não foi identificada, por favor verifique manualmente!';
+                const isSignatureKey = key === signatureKey;
+                const message = isSignatureKey ? messageNotFoundSignature : defaultNotFoundMessage;
+
+                return spacedText(`<span style="color: ${colorTheme.errorColor};">${message}</span>`);
+              }
+            };
+
             const isValidValue = ![customBooleanValues.NOT_FOUND.toString(), null].includes(value);
             const hasJustificationNotFound = value && value.includes(customBooleanValues.FALSE_WITH_JUSTIFICATION.toString());
-            const defaultNotFoundMessage = hasJustificationNotFound ? value : 'Não identificado';
-            const signatureKey = 'Assinatura';
-            const messageNotFoundSignature = 'A assinatura não foi identificada, por favor verifique manualmente!';
-            const notFoundMessage = key === signatureKey ? messageNotFoundSignature : defaultNotFoundMessage;
+            const isValidValueOrPositiveJustification = isValidValue && !hasJustificationNotFound;
 
-            let checklistItem = `<input type="checkbox" ${isValidValue && !hasJustificationNotFound ? 'checked' : ''} disabled> <b>${key}</b>:<br>`;
-            checklistItem += spacedText(
-              isValidValue && !hasJustificationNotFound ? value : `<span style="color: ${colorTheme.errorColor};">${notFoundMessage}</span>`,
-            );
+            let checklistItem = `<input type="checkbox" ${isValidValueOrPositiveJustification ? 'checked' : ''} disabled> <b>${key}</b>:<br>`;
+            checklistItem += getMessage(key, value, isValidValue, hasJustificationNotFound);
+
             return checklistItem;
           };
 

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1162,17 +1162,14 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
             const spacedText = (text: string) => `<div style="padding-left: 20px; margin-bottom: 10px;">${text}</div>`;
             const hasValue = ![customBooleanValues.NOT_FOUND.toString(), null].includes(value);
             const isMachineOrEquipment = value && value.includes(customBooleanValues.NOT_MACHINE.toString());
+            const equipmentValue = isMachineOrEquipment ? value : 'Não identificado';
 
             let checklistItem = `<input type="checkbox" ${hasValue && !isMachineOrEquipment ? 'checked' : ''} disabled> <b>${key}</b>:<br>`;
             checklistItem += spacedText(
               hasValue && !isMachineOrEquipment
                 ? value
                 : `<span style="color: ${colorTheme.errorColor};">${
-                    key === 'Assinatura'
-                      ? 'A assinatura não foi identificada, por favor verifique manualmente!'
-                      : isMachineOrEquipment
-                        ? value
-                        : 'Não identificado'
+                    key === 'Assinatura' ? 'A assinatura não foi identificada, por favor verifique manualmente!' : equipmentValue
                   }</span>`,
             );
             return checklistItem;

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1161,15 +1161,20 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
 
             const spacedText = (text: string) => `<div style="padding-left: 20px; margin-bottom: 10px;">${text}</div>`;
             const hasValue = ![customBooleanValues.NOT_FOUND.toString(), null].includes(value);
+            const isMachineOrEquipment = value && value.includes(customBooleanValues.NOT_MACHINE.toString());
 
-            let checklistItem = `<input type="checkbox" ${hasValue ? 'checked' : ''} disabled> <b>${key}</b>:<br>`;
-            checklistItem += hasValue
-              ? spacedText(value)
-              : spacedText(
-                  `<span style="color: ${colorTheme.errorColor};">${
-                    key === 'Assinatura' ? 'A assinatura não foi identificada, por favor verifique manualmente!' : 'Não identificado'
+            let checklistItem = `<input type="checkbox" ${hasValue && !isMachineOrEquipment ? 'checked' : ''} disabled> <b>${key}</b>:<br>`;
+            checklistItem += spacedText(
+              hasValue && !isMachineOrEquipment
+                ? value
+                : `<span style="color: ${colorTheme.errorColor};">${
+                    key === 'Assinatura'
+                      ? 'A assinatura não foi identificada, por favor verifique manualmente!'
+                      : isMachineOrEquipment
+                        ? value
+                        : 'Não identificado'
                   }</span>`,
-                );
+            );
             return checklistItem;
           };
 

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1161,7 +1161,8 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
 
             const spacedText = (text: string) => `<div style="padding-left: 20px; margin-bottom: 10px;">${text}</div>`;
             const getMessage = (key: string, value: any, validValue: boolean, justificationNotFound: boolean) => {
-              if (validValue && !justificationNotFound) {
+              const isSuccessfulMessage = validValue && !justificationNotFound;
+              if (isSuccessfulMessage) {
                 return spacedText(value);
               } else {
                 const defaultNotFoundMessage = justificationNotFound ? value : 'Não identificado';
@@ -1174,11 +1175,11 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
               }
             };
 
-            const isValidValue = ![customBooleanValues.NOT_FOUND.toString(), null].includes(value);
+            const isValidValue = value !== null && customBooleanValues.NOT_FOUND.toString() !== value;
             const hasJustificationNotFound = value && value.includes(customBooleanValues.FALSE_WITH_JUSTIFICATION.toString());
-            const isValidValueOrPositiveJustification = isValidValue && !hasJustificationNotFound;
+            const shouldCheckboxBeChecked = isValidValue && !hasJustificationNotFound;
 
-            let checklistItem = `<input type="checkbox" ${isValidValueOrPositiveJustification ? 'checked' : ''} disabled> <b>${key}</b>:<br>`;
+            let checklistItem = `<input type="checkbox" ${shouldCheckboxBeChecked ? 'checked' : ''} disabled> <b>${key}</b>:<br>`;
             checklistItem += getMessage(key, value, isValidValue, hasJustificationNotFound);
 
             return checklistItem;

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1161,7 +1161,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
 
             const spacedText = (text: string) => `<div style="padding-left: 20px; margin-bottom: 10px;">${text}</div>`;
             const hasValue = ![customBooleanValues.NOT_FOUND.toString(), null].includes(value);
-            const isMachineOrEquipment = value && value.includes(customBooleanValues.NOT_MACHINE.toString());
+            const isMachineOrEquipment = value && value.includes(customBooleanValues.FALSE_WITH_JUSTIFICATION.toString());
             const equipmentValue = isMachineOrEquipment ? value : 'Não identificado';
 
             let checklistItem = `<input type="checkbox" ${hasValue && !isMachineOrEquipment ? 'checked' : ''} disabled> <b>${key}</b>:<br>`;

--- a/flowise-embed/src/utils/fileClassificationUtils.ts
+++ b/flowise-embed/src/utils/fileClassificationUtils.ts
@@ -57,7 +57,7 @@ Conferências:
 • Máquina/Equipamento
 • Marca - (se mercadoria é máquina ou equipamento)
 • Modelo - (se mercadoria é máquina ou equipamento)
-• Possui Ex-tarifário - (true/false)
+• Possui Ex-tarifário - (Se sim, justifique o porque/Se não, justifique o porque)
 • Multiplicação de valor unitário = quantidade comercializada de cada item
 • Somatório dos itens = valor total informado
 • Se importação direta: Notify = Importador
@@ -69,7 +69,7 @@ Conferências:
 export const conferencesDefault = `
 Conferências:
 • Máquina/Equipamento
-• Possui Ex-tarifário - (true/false)`;
+• Possui Ex-tarifário - (Se sim, justifique o porque/Se não, justifique o porque)`;
 
 export const checklistCeMercante = `
 • Número do conhecimento de embarque

--- a/flowise-embed/src/utils/fileClassificationUtils.ts
+++ b/flowise-embed/src/utils/fileClassificationUtils.ts
@@ -57,7 +57,7 @@ Conferências:
 • Máquina/Equipamento
 • Marca - (se mercadoria é máquina ou equipamento)
 • Modelo - (se mercadoria é máquina ou equipamento)
-• Possui Ex-tarifário - (Se sim, justifique o porque/Se não, justifique o porque)
+• Possui Ex-tarifário - (Sim/Não, sempre justificando)
 • Multiplicação de valor unitário = quantidade comercializada de cada item
 • Somatório dos itens = valor total informado
 • Se importação direta: Notify = Importador
@@ -69,7 +69,7 @@ Conferências:
 export const conferencesDefault = `
 Conferências:
 • Máquina/Equipamento
-• Possui Ex-tarifário - (Se sim, justifique o porque/Se não, justifique o porque)`;
+• Possui Ex-tarifário - (Sim/Não, sempre justificando)`;
 
 export const checklistCeMercante = `
 • Número do conhecimento de embarque

--- a/flowise-embed/src/utils/fileClassificationUtils.ts
+++ b/flowise-embed/src/utils/fileClassificationUtils.ts
@@ -54,7 +54,7 @@ export const defaultChecklist = `
 • Valor da Capatazia - THC, DTHC, THD, Terminal Handling Charge, Terminal Handling Charge Destination
 • Descrição EX-tarifário - (formato "EX-[número]")
 Conferências:
-• Máquina/Equipamento - (true/false)
+• Máquina/Equipamento
 • Marca - (se mercadoria é máquina ou equipamento)
 • Modelo - (se mercadoria é máquina ou equipamento)
 • Possui Ex-tarifário - (true/false)
@@ -68,7 +68,7 @@ Conferências:
 
 export const conferencesDefault = `
 Conferências:
-• Máquina/Equipamento - (true/false)
+• Máquina/Equipamento
 • Possui Ex-tarifário - (true/false)`;
 
 export const checklistCeMercante = `

--- a/flowise-embed/src/utils/jsonUtils.ts
+++ b/flowise-embed/src/utils/jsonUtils.ts
@@ -1,7 +1,7 @@
 export enum customBooleanValues {
   NOT_FOUND = 'Não consta',
   FOUND = 'Consta',
-  NOT_MACHINE = 'Não, não é uma máquina',
+  NOT_MACHINE = 'Não, ',
 }
 
 export function sanitizeJson<T>(json: T): T {

--- a/flowise-embed/src/utils/jsonUtils.ts
+++ b/flowise-embed/src/utils/jsonUtils.ts
@@ -1,6 +1,7 @@
 export enum customBooleanValues {
   NOT_FOUND = 'Não consta',
   FOUND = 'Consta',
+  NOT_MACHINE = 'Não, não é uma máquina',
 }
 
 export function sanitizeJson<T>(json: T): T {

--- a/flowise-embed/src/utils/jsonUtils.ts
+++ b/flowise-embed/src/utils/jsonUtils.ts
@@ -1,7 +1,7 @@
 export enum customBooleanValues {
   NOT_FOUND = 'Não consta',
   FOUND = 'Consta',
-  NOT_MACHINE = 'Não, ',
+  FALSE_WITH_JUSTIFICATION = 'Não, ',
 }
 
 export function sanitizeJson<T>(json: T): T {


### PR DESCRIPTION
- Adicionado trecho para marcar ou desmarcar checklist na conferência de máquina e equipamento e mostrar a resposta que a IA gerou.
- Foi removido também o true e false que estava no checklist do item de máquina/equipamento

![Captura de Tela 2024-10-18 às 10 11 47](https://github.com/user-attachments/assets/77727fb3-4e0d-42b8-8e74-d419492e5044)
![Captura de Tela 2024-10-18 às 10 11 53](https://github.com/user-attachments/assets/2e022f21-847e-4dd3-a4b6-732b069ba158)

Após adicionar o do EX-Tarifario:
![Captura de Tela 2024-10-18 às 10 48 05](https://github.com/user-attachments/assets/21ec4026-a747-4c98-9cca-92e5688d9064)
![Captura de Tela 2024-10-18 às 10 48 13](https://github.com/user-attachments/assets/943738c7-d630-4f31-9d84-a733f05541ce)

