### PR TITLE
Resolução do problema de renderização do modal no Google Chrome

### DIFF
--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1782,6 +1782,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
                   sendMessageSound={props.textInput?.sendMessageSound}
                   sendSoundLocation={props.textInput?.sendSoundLocation}
                   startProcessingFiles={startProcessingFiles}
+                  setIsUploadModalOpen={setIsUploadModalOpen}
                 />
               )
             ) : (
@@ -1793,15 +1794,6 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
                       text={messageUtils.UPLOAD_BUTTON_LABEL}
                       disabled={isUploadButtonDisabled()}
                     />
-                    <FileUploadModal
-                      isOpen={isUploadModalOpen()}
-                      onClose={() => setIsUploadModalOpen(false)}
-                      onUploadSubmit={startProcessingFiles}
-                      modalTitle={messageUtils.MODAL_TITLE}
-                      uploadLabel={messageUtils.UPLOADING_LABEL}
-                      uploadingButtonLabel={messageUtils.MODAL_BUTTON}
-                      errorMessage={messageUtils.FILE_TYPE_NOT_SUPPORTED}
-                    />
                   </>
                 ) : null}
               </>
@@ -1812,6 +1804,15 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
             badgeBackgroundColor={props.badgeBackgroundColor}
             poweredByTextColor={props.poweredByTextColor}
             botContainer={botContainer}
+          />
+          <FileUploadModal
+            isOpen={isUploadModalOpen()}
+            onClose={() => setIsUploadModalOpen(false)}
+            onUploadSubmit={startProcessingFiles}
+            modalTitle={messageUtils.MODAL_TITLE}
+            uploadLabel={messageUtils.UPLOADING_LABEL}
+            uploadingButtonLabel={messageUtils.MODAL_BUTTON}
+            errorMessage={messageUtils.FILE_TYPE_NOT_SUPPORTED}
           />
         </div>
       </div>

--- a/flowise-embed/src/components/inputs/textInput/components/TextInput.tsx
+++ b/flowise-embed/src/components/inputs/textInput/components/TextInput.tsx
@@ -127,7 +127,7 @@ export const TextInput = (props: Props) => {
               type="button"
               class="m-0 h-14 flex items-center justify-center"
               isDisabled={props.disabled || isSendButtonDisabled()}
-              on:click={() => createEffect(() => props.setIsUploadModalOpen(true))}
+              on:click={() => props.setIsUploadModalOpen(true)}
             >
               <span style={{ 'font-family': 'Poppins, sans-serif' }}>Image Upload</span>
             </ImageUploadButton>

--- a/flowise-embed/src/components/inputs/textInput/components/TextInput.tsx
+++ b/flowise-embed/src/components/inputs/textInput/components/TextInput.tsx
@@ -5,11 +5,7 @@ import { SendButton } from '@/components/buttons/SendButton';
 import { FileEvent, UploadsConfig } from '@/components/Bot';
 import { ImageUploadButton } from '@/components/buttons/ImageUploadButton';
 import { RecordAudioButton } from '@/components/buttons/RecordAudioButton';
-import { create } from 'lodash';
-import { FileUploadModal } from '@/features/modal';
-import { messageUtils } from '@/utils/messageUtils';
 import { UploadFile } from '@solid-primitives/upload';
-import { FileMapping } from '@/utils/fileUtils';
 
 type Props = {
   placeholder?: string;
@@ -30,6 +26,7 @@ type Props = {
   sendMessageSound?: boolean;
   sendSoundLocation?: string;
   startProcessingFiles: (files: UploadFile[]) => Promise<void>;
+  setIsUploadModalOpen: Setter<boolean>;
 };
 
 const defaultBackgroundColor = '#ffffff';
@@ -106,11 +103,6 @@ export const TextInput = (props: Props) => {
     if (event.target) event.target.value = '';
   };
 
-  const processFiles = async () => {
-    setIsUploadModalOpen(false);
-    props.startProcessingFiles([]);
-  };
-
   return (
     <div
       class="w-full h-auto max-h-[192px] min-h-[56px] flex flex-col items-end justify-between chatbot-input border border-[#eeeeee]"
@@ -128,31 +120,19 @@ export const TextInput = (props: Props) => {
         </div>
       </Show>
       <div class="w-full flex items-end justify-between">
-        {props.uploadsConfig?.isImageUploadAllowed ? (
+        <Show when={props.uploadsConfig?.isImageUploadAllowed}>
           <>
             <ImageUploadButton
               buttonColor={props.sendButtonColor}
               type="button"
               class="m-0 h-14 flex items-center justify-center"
               isDisabled={props.disabled || isSendButtonDisabled()}
-              on:click={() => setIsUploadModalOpen(true)}
+              on:click={() => createEffect(() => props.setIsUploadModalOpen(true))}
             >
               <span style={{ 'font-family': 'Poppins, sans-serif' }}>Image Upload</span>
             </ImageUploadButton>
-            <FileUploadModal
-              isOpen={isUploadModalOpen()}
-              onClose={() => setIsUploadModalOpen(false)}
-              onUploadSubmit={(files: UploadFile[]) => {
-                setIsUploadModalOpen(false);
-                props.startProcessingFiles(files);
-              }}
-              modalTitle={messageUtils.MODAL_TITLE}
-              uploadLabel={messageUtils.UPLOADING_LABEL}
-              uploadingButtonLabel={messageUtils.MODAL_BUTTON}
-              errorMessage={messageUtils.FILE_TYPE_NOT_SUPPORTED}
-            />
           </>
-        ) : null}
+        </Show>
         <ShortTextInput
           ref={inputRef as HTMLTextAreaElement}
           onInput={handleInput}


### PR DESCRIPTION
O estado que garantia a renderização do modal e do botão estava travando a renderização do mesmo na parte do compliance da análise crítica. Então retiramos o modal em si do ternário e o deixamos fora do html para que pudesse ser ativado somente via estado, usando o setIsUploadModalOpen e também passando esse setter como prop para o textInput. 