### PR TITLE
[ACI-101] - Suporte ao histórico de chats

### DIFF
--- a/compliance.html
+++ b/compliance.html
@@ -10,7 +10,7 @@
         import Chatbot from './flowise-embed/dist/web.js';
         import {menuItems} from './js/data.js'
         Chatbot.initMenu({
-          currentId: 'compliance',
+          currentFlow: 'compliance',
             items: menuItems,
           });
         Chatbot.initFull({

--- a/critical_analysis.html
+++ b/critical_analysis.html
@@ -10,7 +10,7 @@
         import Chatbot from './flowise-embed/dist/web.js';
     import {menuItems} from './js/data.js'
         Chatbot.initMenu({
-          currentId: 'analise_critica',
+          currentFlow: 'analise_critica',
             items: menuItems,
           });
         Chatbot.initFull({

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1387,7 +1387,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     let fileProcessed = null;
 
     if (![DocumentTypes.LICENCA_DE_IMPORTACAO.toString(), DocumentTypes.LPCO.toString()].includes(fileMap.type)) {
-      fileProcessed = await documentService.checkDocumentForAlreadyProcessedData(fileMap, props.flow, chatId());
+      fileProcessed = await documentService.getProcessedDocumentData(fileMap, props.flow, chatId());
     }
 
     if (fileProcessed != null) {
@@ -1480,7 +1480,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     const file = fileMap.file as UploadFile;
     const urls = await processFileToSend(file.file);
 
-    const fileProcessed = await documentService.checkDocumentForAlreadyProcessedData(fileMap, props.flow, chatId());
+    const fileProcessed = await documentService.getProcessedDocumentData(fileMap, props.flow, chatId());
 
     if (fileProcessed) {
       let processedDocumentJson = JSON.parse(fileProcessed);

--- a/flowise-embed/src/constants.ts
+++ b/flowise-embed/src/constants.ts
@@ -28,6 +28,7 @@ export const constants = {
   n8nFlowFetchChatDocumentRelation: 'a4bc4d9b-e44c-4813-b8f2-885cd1a5380c',
   n8nFlowFetchDocumentsByChatId: '6aa6bc8f-2aba-4d79-b7ce-b313bb23e797',
   n8nFlowFetchChatIdsForFlow: '8093dd32-25a4-4d40-80b4-ab105893d5c2',
+  n8nFlowSendDeleteChatRequest: '8093dd32-25a4-4d40-80b4-ab105893d5c2',
 };
 
 export const defaultMenuProps: MenuProps = {

--- a/flowise-embed/src/constants.ts
+++ b/flowise-embed/src/constants.ts
@@ -29,6 +29,7 @@ export const constants = {
   n8nFlowFetchDocumentsByChatId: '6aa6bc8f-2aba-4d79-b7ce-b313bb23e797',
   n8nFlowFetchChatIdsForFlow: '8093dd32-25a4-4d40-80b4-ab105893d5c2',
   n8nFlowSendDeleteChatRequest: 'd92f2f25-788c-4545-b3b5-94e4c85d9ef5',
+  n8nFlowSendUpdateChatRequest: 'ebdf0721-9bba-467a-80fd-0c5c74965dfc',
 };
 
 export const defaultMenuProps: MenuProps = {

--- a/flowise-embed/src/constants.ts
+++ b/flowise-embed/src/constants.ts
@@ -28,7 +28,7 @@ export const constants = {
   n8nFlowFetchChatDocumentRelation: 'a4bc4d9b-e44c-4813-b8f2-885cd1a5380c',
   n8nFlowFetchDocumentsByChatId: '6aa6bc8f-2aba-4d79-b7ce-b313bb23e797',
   n8nFlowFetchChatIdsForFlow: '8093dd32-25a4-4d40-80b4-ab105893d5c2',
-  n8nFlowSendDeleteChatRequest: '8093dd32-25a4-4d40-80b4-ab105893d5c2',
+  n8nFlowSendDeleteChatRequest: 'd92f2f25-788c-4545-b3b5-94e4c85d9ef5',
 };
 
 export const defaultMenuProps: MenuProps = {

--- a/flowise-embed/src/constants.ts
+++ b/flowise-embed/src/constants.ts
@@ -27,6 +27,7 @@ export const constants = {
   n8nFlowGetDataFromSupabase: 'cce1b9da-cf8e-46cb-b36a-9028c13f1a4e',
   n8nFlowFetchChatDocumentRelation: 'a4bc4d9b-e44c-4813-b8f2-885cd1a5380c',
   n8nFlowFetchDocumentsByChatId: '6aa6bc8f-2aba-4d79-b7ce-b313bb23e797',
+  n8nFlowFetchChatIdsForFlow: '8093dd32-25a4-4d40-80b4-ab105893d5c2',
 };
 
 export const defaultMenuProps: MenuProps = {

--- a/flowise-embed/src/constants.ts
+++ b/flowise-embed/src/constants.ts
@@ -33,7 +33,7 @@ export const constants = {
 };
 
 export const defaultMenuProps: MenuProps = {
-  currentId: '',
+  currentFlow: '',
   items: [],
   fillColor: '#F4F6FF',
 };

--- a/flowise-embed/src/features/menu/components/Menu.tsx
+++ b/flowise-embed/src/features/menu/components/Menu.tsx
@@ -17,7 +17,6 @@ export const Menu = (props: MenuProps) => {
   const [currentFlow, setCurrentFLow] = createSignal(localStorage.getItem('currentFlow') || props.currentFlow);
 
   const handleClick = (flow: string) => {
-    console.log(props);
     setCurrentFLow(flow);
     localStorage.setItem('currentFlow', flow);
   };

--- a/flowise-embed/src/features/menu/components/Menu.tsx
+++ b/flowise-embed/src/features/menu/components/Menu.tsx
@@ -8,18 +8,18 @@ import DocumentsDBService from '@/service/documentsDBService';
 
 const documentService = new DocumentsDBService();
 export interface MenuProps {
-  currentId: string;
+  currentFlow: string;
   items: MenuItemProps[];
   fillColor?: string;
 }
 export const Menu = (props: MenuProps) => {
   const [open, setOpen] = createSignal(false);
-  const [currentId, setCurrentId] = createSignal(localStorage.getItem('currentId') || props.currentId);
+  const [currentFlow, setCurrentFLow] = createSignal(localStorage.getItem('currentFlow') || props.currentFlow);
 
-  const handleClick = (id: string) => {
-    setCurrentId(id);
-    localStorage.setItem('currentId', id);
-    documentService.getChatIdsByFlow(id);
+  const handleClick = (flow: string) => {
+    console.log(props);
+    setCurrentFLow(flow);
+    localStorage.setItem('currentFlow', flow);
   };
 
   return (
@@ -40,7 +40,7 @@ export const Menu = (props: MenuProps) => {
               <div class="menu-items">
                 <div class="menu-text">Escolha qual tarefa deseja realizar</div>
                 <For each={props.items}>
-                  {(item) => <MenuItem {...item} selected={item.id === currentId()} onClick={() => handleClick(item.id)} />}
+                  {(item) => <MenuItem {...item} selected={item.flow === currentFlow()} onClick={() => handleClick(item.flow)} />}
                 </For>
               </div>
               <div class="menu-footer">

--- a/flowise-embed/src/features/menu/components/Menu.tsx
+++ b/flowise-embed/src/features/menu/components/Menu.tsx
@@ -4,6 +4,9 @@ import { MenuButton } from './MenuButton';
 import { MenuItem, MenuItemProps } from './MenuItem';
 import { LogoInterseas } from '@/components/icons/LogoInterseas';
 import { XIcon } from '@/components/icons/XIcon';
+import DocumentsDBService from '@/service/documentsDBService';
+
+const documentService = new DocumentsDBService();
 export interface MenuProps {
   currentId: string;
   items: MenuItemProps[];
@@ -16,6 +19,7 @@ export const Menu = (props: MenuProps) => {
   const handleClick = (id: string) => {
     setCurrentId(id);
     localStorage.setItem('currentId', id);
+    documentService.getChatIdsByFlow(id);
   };
 
   return (

--- a/flowise-embed/src/features/menu/components/MenuItem.tsx
+++ b/flowise-embed/src/features/menu/components/MenuItem.tsx
@@ -1,5 +1,5 @@
 export interface MenuItemProps {
-  id: string;
+  flow: string;
   title: string;
   subtitle?: string;
   selected?: boolean;
@@ -8,7 +8,7 @@ export interface MenuItemProps {
 
 export const MenuItem = (props: MenuItemProps) => {
   return (
-    <a href={`./${props.id}.html`} onClick={props.onClick}>
+    <a href={`./${props.flow}.html`} onClick={props.onClick}>
       <div class={`menu-item ${props.selected ? 'selected' : ''}`}>
         <p>
           <b>{props.title}</b>

--- a/flowise-embed/src/pages/Home/Home.tsx
+++ b/flowise-embed/src/pages/Home/Home.tsx
@@ -9,12 +9,11 @@ export interface HomeProps {
 }
 
 export const Home = (props: HomeProps) => {
-  const [currentId, setCurrentId] = createSignal('initialId');
+  const [currentFlow, setCurrentFlow] = createSignal('');
 
-  const handleCardClick = (id: string) => {
-    setCurrentId(id);
-    localStorage.setItem('currentId', id);
-    documentService.getChatIdsByFlow(id);
+  const handleCardClick = (flow: string) => {
+    setCurrentFlow(flow);
+    localStorage.setItem('currentFlow', flow);
   };
 
   return (
@@ -26,7 +25,7 @@ export const Home = (props: HomeProps) => {
           <p>Escolha qual tarefa deseja realizar abaixo</p>
         </div>
         <div class="card-container">
-          <For each={props.items}>{(item) => <CardModel {...item} onIdChange={handleCardClick} />}</For>
+          <For each={props.items}>{(item) => <CardModel {...item} onFlowChange={handleCardClick} />}</For>
         </div>
       </main>
       <footer>

--- a/flowise-embed/src/pages/Home/Home.tsx
+++ b/flowise-embed/src/pages/Home/Home.tsx
@@ -1,12 +1,22 @@
-import { For } from 'solid-js';
+import { For, createSignal } from 'solid-js';
 import styles from './home.css';
 import { CardModel, CardModelProps } from './components/CardModel';
+import DocumentsDBService from '@/service/documentsDBService';
 
+const documentService = new DocumentsDBService();
 export interface HomeProps {
   items: CardModelProps[];
 }
 
 export const Home = (props: HomeProps) => {
+  const [currentId, setCurrentId] = createSignal('initialId');
+
+  const handleCardClick = (id: string) => {
+    setCurrentId(id);
+    localStorage.setItem('currentId', id);
+    documentService.getChatIdsByFlow(id);
+  };
+
   return (
     <>
       <style>{styles}</style>
@@ -16,7 +26,7 @@ export const Home = (props: HomeProps) => {
           <p>Escolha qual tarefa deseja realizar abaixo</p>
         </div>
         <div class="card-container">
-          <For each={props.items}>{(item) => <CardModel {...item} />}</For>
+          <For each={props.items}>{(item) => <CardModel {...item} onIdChange={handleCardClick} />}</For>
         </div>
       </main>
       <footer>

--- a/flowise-embed/src/pages/Home/components/CardModel.tsx
+++ b/flowise-embed/src/pages/Home/components/CardModel.tsx
@@ -2,11 +2,11 @@ import { Component } from 'solid-js';
 import { RigthArrowIcon } from '@/components/icons/RigthArrowIcon';
 
 export interface CardModelProps {
-  id: string;
+  flow: string;
   title: string;
   onClick?: () => void;
   bgImage: string;
-  onIdChange?: (id: string) => void;
+  onFlowChange?: (flow: string) => void;
 }
 
 export const CardModel: Component<CardModelProps> = (props) => {
@@ -14,10 +14,11 @@ export const CardModel: Component<CardModelProps> = (props) => {
     if (props.onClick) {
       return props.onClick();
     }
-    if (props.onIdChange) {
-      props.onIdChange(props.id);
+    if (props.onFlowChange) {
+      props.onFlowChange(props.flow);
     }
-    window.location.href = `${props.id}.html`;
+    console.log(props);
+    window.location.href = `${props.flow}.html`;
   };
 
   return (

--- a/flowise-embed/src/pages/Home/components/CardModel.tsx
+++ b/flowise-embed/src/pages/Home/components/CardModel.tsx
@@ -17,7 +17,6 @@ export const CardModel: Component<CardModelProps> = (props) => {
     if (props.onFlowChange) {
       props.onFlowChange(props.flow);
     }
-    console.log(props);
     window.location.href = `${props.flow}.html`;
   };
 

--- a/flowise-embed/src/pages/Home/components/CardModel.tsx
+++ b/flowise-embed/src/pages/Home/components/CardModel.tsx
@@ -6,12 +6,16 @@ export interface CardModelProps {
   title: string;
   onClick?: () => void;
   bgImage: string;
+  onIdChange?: (id: string) => void;
 }
 
 export const CardModel: Component<CardModelProps> = (props) => {
   const onClick = () => {
     if (props.onClick) {
       return props.onClick();
+    }
+    if (props.onIdChange) {
+      props.onIdChange(props.id);
     }
     window.location.href = `${props.id}.html`;
   };

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -177,7 +177,7 @@ class DocumentsDBService {
     }
   }
 
-  public async checkDocumentForAlreadyProcessedData(fileMap: any, agentFlow: Flow, chatId: any): Promise<any> {
+  public async getProcessedDocumentData(fileMap: any, agentFlow: Flow, chatId: any): Promise<string | null> {
     const hashPdf = await pdfToHash(fileMap.file.file);
     const hasBeenProcessed = await this.checkDocumentHash(hashPdf, agentFlow, chatId);
     if (hasBeenProcessed) {

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -114,6 +114,24 @@ class DocumentsDBService {
     }
   }
 
+  private async sendUpdateChatRequest(chatId: string, chatName: string): Promise<any> {
+    try {
+      const response = await fetch(constants.n8nDomain + '/webhook/' + constants.n8nFlowSendUpdateChatRequest, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ chatId, chatName }),
+      });
+
+      const data = await response.json();
+      console.log(data);
+      return data;
+    } catch (error) {
+      throw new Error(`Error updating ChatName:', ${error}`);
+    }
+  }
+
   private async sendDataToDBThroughN8n(tableName: string, data: any): Promise<void> {
     try {
       await this.sendDataToN8n(tableName, data);
@@ -140,6 +158,10 @@ class DocumentsDBService {
 
   private async removeChat(chatId: string): Promise<void> {
     await this.sendDeleteChatRequest(chatId);
+  }
+
+  private async updateChat(chatId: string, chatName: string): Promise<string | null> {
+    return await this.sendUpdateChatRequest(chatId, chatName);
   }
 
   private async extractDocumentData(fileMap: any, textContent: any, agentFlow: Flow, agentResult?: any): Promise<DocumentData> {
@@ -241,6 +263,16 @@ class DocumentsDBService {
       await this.removeChat(chatId);
     } catch (error) {
       console.error('Error deleting chatId:', error);
+      throw error;
+    }
+  }
+
+  public async updateChatName(chatId: string, chatName: string): Promise<string | null> {
+    try {
+      const result = await this.updateChat(chatId, chatName);
+      return result;
+    } catch (error) {
+      console.error('Error updating chatName:', error);
       throw error;
     }
   }

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -100,6 +100,23 @@ class DocumentsDBService {
     }
   }
 
+  private async sendDeleteChatRequest(chatId: string): Promise<boolean> {
+    try {
+      const response = await fetch(constants.n8nDomain + '/webhook/' + constants.n8nFlowSendDeleteChatRequest, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ chatId }),
+      });
+
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      throw new Error(`Error finding chatId on DB:', ${error}`);
+    }
+  }
+
   private async sendDataToDBThroughN8n(tableName: string, data: any): Promise<void> {
     try {
       await this.sendDataToN8n(tableName, data);
@@ -122,6 +139,10 @@ class DocumentsDBService {
 
   private async retrieveChatIdsForFlow(flow: string): Promise<string> {
     return await this.fetchChatIdsForFlow(flow);
+  }
+
+  private async removeChat(chatId: string): Promise<boolean> {
+    return await this.sendDeleteChatRequest(chatId);
   }
 
   private async extractDocumentData(fileMap: any, textContent: any, agentFlow: Flow, agentResult?: any): Promise<DocumentData> {
@@ -215,6 +236,16 @@ class DocumentsDBService {
     } catch (error) {
       console.error('Error finding chatIds by flow:', error);
       return null;
+    }
+  }
+
+  public async deleteChat(chatId: string): Promise<boolean> {
+    try {
+      const result = await this.removeChat(chatId);
+      return result;
+    } catch (error) {
+      console.error('Error deleting chatId:', error);
+      throw error;
     }
   }
 }

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -100,20 +100,17 @@ class DocumentsDBService {
     }
   }
 
-  private async sendDeleteChatRequest(chatId: string): Promise<boolean> {
+  private async sendDeleteChatRequest(chatId: string): Promise<void> {
     try {
-      const response = await fetch(constants.n8nDomain + '/webhook/' + constants.n8nFlowSendDeleteChatRequest, {
+      await fetch(constants.n8nDomain + '/webhook/' + constants.n8nFlowSendDeleteChatRequest, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ chatId }),
       });
-
-      const data = await response.json();
-      return data;
     } catch (error) {
-      throw new Error(`Error finding chatId on DB:', ${error}`);
+      throw new Error(`Error deleting chatId:', ${error}`);
     }
   }
 
@@ -141,8 +138,8 @@ class DocumentsDBService {
     return await this.fetchChatIdsForFlow(flow);
   }
 
-  private async removeChat(chatId: string): Promise<boolean> {
-    return await this.sendDeleteChatRequest(chatId);
+  private async removeChat(chatId: string): Promise<void> {
+    await this.sendDeleteChatRequest(chatId);
   }
 
   private async extractDocumentData(fileMap: any, textContent: any, agentFlow: Flow, agentResult?: any): Promise<DocumentData> {
@@ -239,10 +236,9 @@ class DocumentsDBService {
     }
   }
 
-  public async deleteChat(chatId: string): Promise<boolean> {
+  public async deleteChat(chatId: string): Promise<void> {
     try {
-      const result = await this.removeChat(chatId);
-      return result;
+      await this.removeChat(chatId);
     } catch (error) {
       console.error('Error deleting chatId:', error);
       throw error;

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -83,6 +83,23 @@ class DocumentsDBService {
     }
   }
 
+  private async fetchChatIdsForFlow(flow: string): Promise<any> {
+    try {
+      const response = await fetch(constants.n8nDomain + '/webhook/' + constants.n8nFlowFetchChatIdsForFlow, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ flow }),
+      });
+
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      throw new Error(`Error finding chatId on DB:', ${error}`);
+    }
+  }
+
   private async sendDataToDBThroughN8n(tableName: string, data: any): Promise<void> {
     try {
       await this.sendDataToN8n(tableName, data);
@@ -101,6 +118,10 @@ class DocumentsDBService {
 
   private async doesChatDocumentRelationExist(chatId: any, documentId: any): Promise<boolean> {
     return await this.fetchChatDocumentRelation(chatId, documentId);
+  }
+
+  private async retrieveChatIdsForFlow(flow: string): Promise<string> {
+    return await this.fetchChatIdsForFlow(flow);
   }
 
   private async extractDocumentData(fileMap: any, textContent: any, agentFlow: Flow, agentResult?: any): Promise<DocumentData> {
@@ -185,6 +206,16 @@ class DocumentsDBService {
       return document?.checklist_result;
     }
     return null;
+  }
+
+  public async getChatIdsByFlow(flow: string): Promise<string | null> {
+    try {
+      const chatIds = await this.retrieveChatIdsForFlow(flow);
+      return chatIds;
+    } catch (error) {
+      console.error('Error finding chatIds by flow:', error);
+      return null;
+    }
   }
 }
 

--- a/flowise-embed/src/service/documentsDBService.ts
+++ b/flowise-embed/src/service/documentsDBService.ts
@@ -125,7 +125,6 @@ class DocumentsDBService {
       });
 
       const data = await response.json();
-      console.log(data);
       return data;
     } catch (error) {
       throw new Error(`Error updating ChatName:', ${error}`);

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
       import Chatbot from "./flowise-embed/dist/web.js";
       import { menuItems } from "./js/data.js";
       Chatbot.initMenu({
-        currentId: "home",
+        currentFlow: "home",
         items: menuItems,
         fillColor: "#000000",
       });

--- a/js/data.js
+++ b/js/data.js
@@ -1,16 +1,16 @@
 export const menuItems = [
   {
-    id: "compliance",
+    flow: "compliance",
     title: "Análise de Compliance",
     bgImage: "bg-compliance.jpeg",
   },
   // {
-  //   id: "cost_estimate",
+  //   flow: "cost_estimate",
   //   title: "Estimativa de Custos",
   //   bgImage: "bg-cost-estimate.jpeg",
   // },
   {
-    id: "critical_analysis",
+    flow: "critical_analysis",
     title: "Análise Crítica",
     bgImage: "bg-critical.jpeg",
   },


### PR DESCRIPTION
Desenvolver as chamadas necessárias para o banco de dados para:

Obter a lista de chats de um determinado fluxo (compliance, análise crítica, estimativa de custos)

Atualizar o nome de um chat (para a opção de “renomear” um chat do histórico, conforme o Figma)

Excluir um chat antigo