### PR TITLE
[ACI-102] Menu com histórico de chats

### DIFF
--- a/flowise-embed/src/assets/menu.css
+++ b/flowise-embed/src/assets/menu.css
@@ -10,7 +10,7 @@
     z-index: 1000;
 }
 .menu .menu-opener-button {
-    padding: 1.09375rem 0.625rem;
+    padding: 1.0938rem .625rem;
     position: fixed;
     top: 0;
     left: 0;
@@ -31,17 +31,16 @@
 .menu-content {
     height: 100vh;
     background-color: #FAFAFA;
-    padding: 2rem 0.5rem;
+    padding: 2rem .5rem;
     display: grid;
     grid-template-rows: auto 1fr auto;
-    gap: 0.25rem;
+    gap: .25rem;
     overflow: auto;
     overflow-x: hidden;
-    border-radius: 0px 0.25rem 0.25rem 0px;
+    border-radius: 0px .25rem .25rem 0px;
 }
 .menu-overlay {
     width: 100%;
-    height: 100vh;
 }
 .menu-header {
     min-height: 2.75rem;
@@ -52,7 +51,7 @@
     margin: -2rem -0.625rem 1.25rem;
 }
 .logo {
-    padding-left: 0.625rem;
+    padding-left: .625rem;
 }
 .menu .close-button {
     position: static;
@@ -60,15 +59,16 @@
     padding-right: 1.25rem;
     font-family: sans-serif;
     font-weight: lighter;
-    letter-spacing: 0.0625rem;
+    letter-spacing: .0625rem;
 }
 .menu-items {
     display: flex;
     flex-direction: column;
-    gap: 0.3125rem;
+    gap: .3125rem;
 }
 .menu-text{
-    font-size: 0.875rem;
+    font-family: sans-serif;
+    font-size: .875rem;
     font-weight: 350;
 }
 .menu-item {
@@ -78,7 +78,7 @@
     flex-shrink: 0;
     padding: 0px 1rem;
     align-self: stretch;
-    border-bottom: 0.5px solid #FBA115;
+    border-bottom: .5008px solid #FBA115;
 }
 .menu-item.selected,
 .menu-item:hover {
@@ -95,7 +95,7 @@
     font-style: normal;
     font-weight: 500;
     line-height: 100%;
-    letter-spacing: 0.009375rem;
+    letter-spacing: .0094rem;
 }
 .menu-item p b {
     font-weight: 500;
@@ -104,7 +104,7 @@
     display: flex;
     font-family: var(--chatbot-container-font-family, sans-serif);
     height: 3.5rem;
-    font-size: 0.875rem;
+    font-size: .875rem;
     font-weight: 500;
     line-height: 18px;
     align-items: center;
@@ -116,6 +116,7 @@
 }
 .menu-history-item-wrapper {
     display: flex;
+    position: relative;
     height: 2.5rem;
     width: 100%;
     padding: 1rem;
@@ -129,6 +130,104 @@
     font-weight: 500;
     letter-spacing: .0094rem;
 }
+.menu-history-option{
+    position: absolute;
+    bottom: 2.2rem;
+    border-radius: .3125rem;
+    right: 0;
+    padding: 3px 9px;
+    width: 10.375rem;
+    height: 6.375rem;
+    background-color: #ECECEC;
+    box-shadow: 0px 4px 4px 0px #00000040;
+}
+.menu-history-option-wrapper{
+    display: flex;
+    width: 100%;
+    height: 100%;
+    align-items: center;
+    justify-content: space-around;
+    flex-direction: column;
+}
+.menu-history-option-edit, .menu-history-option-delete{
+    width: 100%;
+    height: 100%;
+}
+.menu-history-option-edit {
+    border-bottom: .5008px solid #FD9102;
+}
+.menu-history-option-delete button {
+    color: #E41D1D;
+}
+.menu-history-option-wrapper div button {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    align-items: center;
+    gap: .75rem;
+    font-size: .875rem;
+    font-family: var(--chatbot-container-font-family, sans-serif);
+}
+.modal-delete {
+    z-index: 1001;
+    position: relative;
+}
+.modal-delete-wrapper {
+    z-index: 1001;
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+}
+.modal-delete-content{
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    text-align: center;
+    padding: 1.75rem 1rem;
+    width: 20.75rem;
+    height: 13.125rem;
+    font-family: var(--chatbot-container-font-family, sans-serif);
+    border-radius: .25rem;
+    background-color: #DFE9EB;
+}
+.modal-delete-content h6{
+    font-weight: 700;
+    font-size: 16px;
+    margin-bottom: .5rem;
+}
+.modal-delete-content span{
+    font-weight: 400;
+    font-size: 16px;
+    margin-bottom: 2rem;
+}
+.modal-delete-btn-wrapper {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    gap: 10px;
+}
+.modal-delete-btn-wrapper button {
+    padding: 9px 14px;
+    text-transform: uppercase;
+    width: 50%;
+    height: 49px;
+}
+.modal-delete-btn-cancel{
+    color: #136FEE;
+    border: .125rem solid #136FEE;
+}
+.modal-delete-btn-delete{
+    color: #FAFAFA;
+    background-color: #136FEE;
+}
 .menu-footer {
     display: flex;
     justify-content: center;
@@ -141,7 +240,7 @@
     font-style: normal;
     font-weight: 400;
     line-height: 1.05rem;
-    letter-spacing: 0.03125rem;
+    letter-spacing: .0313rem;
 }
 .menu-footer p b {
     font-weight: 700;
@@ -153,11 +252,11 @@
 }
 /* Chrome, Edge and Safari */
 *::-webkit-scrollbar {
-    width: 0.5rem;
+    width: .5rem;
 }
 *::-webkit-scrollbar-track {
     background-color: #DFE9EB;
-    border: 0.1875rem solid #FFFFFF;
+    border: .1875rem solid #FFFFFF;
 }
 *::-webkit-scrollbar-track:hover {
     background-color: #B8C0C2;
@@ -167,7 +266,7 @@
 }
 *::-webkit-scrollbar-thumb {
     background-color: #43474E;
-    border: 0.1875rem solid #FFFFFF;
+    border: .1875rem solid #FFFFFF;
 }
 *::-webkit-scrollbar-thumb:hover {
     background-color: #43474E;

--- a/flowise-embed/src/assets/menu.css
+++ b/flowise-embed/src/assets/menu.css
@@ -109,11 +109,19 @@
     font-weight: 500;
     line-height: 18px;
     align-items: center;
+    padding-top: 2rem;
 }
 .menu-history-date-label {
     font-size: .75rem;
     font-family: var(--chatbot-container-font-family, sans-serif);
     color: #C4C6CF;
+    padding: .5rem 0px;
+}
+.menu-history-item-group {
+    display: flex;
+    flex-direction: column;
+    gap: .3125rem;
+    width: 100%;
 }
 .menu-history-item-wrapper {
     position: relative;

--- a/flowise-embed/src/assets/menu.css
+++ b/flowise-embed/src/assets/menu.css
@@ -128,7 +128,9 @@
     flex-direction: column;
     gap: .3125rem;
     width: 100%;
-    min-height: 50dvh;
+}
+.menu-history-item-group.min-height {
+    min-height: 12.5rem; 
 }
 .menu-history-item-wrapper {
     position: relative;

--- a/flowise-embed/src/assets/menu.css
+++ b/flowise-embed/src/assets/menu.css
@@ -4,8 +4,14 @@
 
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@100;300;400;500;600;700&family=Inter:wght@100;300;400;500;600;700&display=swap');
 
+:host {
+    --chatbot-container-font-family: "Inter", sans-serif;
+    --chatbot-container-font-family-secondary: "IBM Plex Sans", sans-serif;
+    --menu-content-background-color: #FAFAFA;
+    --orange-border-color: #FBA115;
+}
 .menu {
-    font-family: "IBM Plex Sans", sans-serif;
+    font-family: var(--chatbot-container-font-family-secondary);
     position: relative;
     z-index: 1000;
 }
@@ -30,14 +36,14 @@
 }
 .menu-content {
     height: 100vh;
-    background-color: #FAFAFA;
-    padding: 2rem .5rem;
+    background-color: var(--menu-content-background-color);
+    padding: 2rem .5rem .5rem 1rem;
     display: grid;
     grid-template-rows: auto 1fr auto;
     gap: .25rem;
     overflow: auto;
     overflow-x: hidden;
-    border-radius: 0px .25rem .25rem 0px;
+    border-radius: 0 .25rem .25rem 0;
 }
 .menu-overlay {
     width: 100%;
@@ -57,7 +63,6 @@
     position: static;
     padding: 0;
     padding-right: 1.25rem;
-    font-family: sans-serif;
     font-weight: lighter;
     letter-spacing: .0625rem;
 }
@@ -66,9 +71,10 @@
     flex-direction: column;
     gap: .3125rem;
     overflow-y: scroll;
+    scrollbar-width: none;
 }
 .menu-text{
-    font-family: sans-serif;
+    font-family: var(--chatbot-container-font-family-secondary);
     font-size: .875rem;
     font-weight: 350;
 }
@@ -77,9 +83,9 @@
     height: 3.5rem;
     align-items: center;
     flex-shrink: 0;
-    padding: 0px 1rem;
+    padding: 0 1rem;
     align-self: stretch;
-    border-bottom: .5008px solid #FBA115;
+    border-bottom: .0313rem solid var(--orange-border-color);
 }
 .menu-item.selected,
 .menu-item:hover {
@@ -88,7 +94,7 @@
 }
 .menu-item.selected p,
 .menu-item:hover p {
-    color: #FAFAFA;
+    color: var(--menu-content-background-color);
 }
 .menu-item p {
     color: #136FEE;
@@ -103,30 +109,32 @@
 }
 .menu-history {
     display: flex;
-    font-family: var(--chatbot-container-font-family, sans-serif);
+    font-family: var(--chatbot-container-font-family-secondary);
     height: 3.5rem;
     font-size: .875rem;
     font-weight: 500;
-    line-height: 18px;
+    line-height: 1.125rem;
     align-items: center;
     padding-top: 2rem;
 }
 .menu-history-date-label {
     font-size: .75rem;
-    font-family: var(--chatbot-container-font-family, sans-serif);
+    font-family: var(--chatbot-container-font-family-secondary);
     color: #C4C6CF;
-    padding: .5rem 0px;
+    padding: .5rem 0;
 }
 .menu-history-item-group {
     display: flex;
     flex-direction: column;
     gap: .3125rem;
     width: 100%;
+    min-height: 50dvh;
 }
 .menu-history-item-wrapper {
     position: relative;
     width: 100%;
     overflow-y: scroll;
+    scrollbar-width: none;
 }
 .menu-history-item{
     display: flex;
@@ -136,18 +144,18 @@
     overflow: visible;
     justify-content: space-between;
     align-items: center;
-    border-bottom: .0313rem solid #FD9102;
+    border-bottom: .0313rem solid var(--orange-border-color);
 }
 .menu-history-item-wrapper form {
-    height: 40px;
+    height: 2.5rem;
     width: 100%;
 }
 .menu-history-item-wrapper form input {
     font-family: var(--chatbot-container-font-family, sans-serif);
     width: 100%;
     height: 100%;
-    border: 2.5px solid #136FEE;
-    padding: 0 15px;
+    border: .1563rem solid #136FEE;
+    padding: 0 .9375rem;
 }
 .menu-history-item-wrapper span {
     font-family: var(--chatbot-container-font-family, sans-serif);
@@ -158,13 +166,12 @@
 .menu-history-option{
     position: absolute;
     border-radius: .3125rem;
-
-    padding: 3px 9px;
+    padding: .1875rem .5625rem;
     width: 10.375rem;
     height: 6.375rem;
     z-index: 1002;
-    background-color: #ECECEC;
-    box-shadow: 0px 4px 4px 0px #00000040;
+    background-color: var(--menu-content-background-color);
+    box-shadow: 0 .25rem .25rem 0 #00000040;
 }
 .menu-history-option.bottom {
     top: 100%;
@@ -176,18 +183,16 @@
 }
 .menu-history-option-wrapper{
     display: flex;
-    width: 100%;
-    height: 100%;
     align-items: center;
     justify-content: space-around;
     flex-direction: column;
 }
-.menu-history-option-edit, .menu-history-option-delete{
+.menu-history-option-wrapper, .menu-history-option-edit, .menu-history-option-delete{
     width: 100%;
     height: 100%;
 }
 .menu-history-option-edit {
-    border-bottom: .5008px solid #FD9102;
+    border-bottom: .0313rem solid var(--orange-border-color);
 }
 .menu-history-option-delete button {
     color: #E41D1D;
@@ -227,31 +232,31 @@
     padding: 1.75rem 1rem;
     width: 20.75rem;
     height: 13.125rem;
-    font-family: var(--chatbot-container-font-family, sans-serif);
+    font-family: var(--chatbot-container-font-family);
     border-radius: .25rem;
-    background-color: #DFE9EB;
+    background-color: var(--menu-content-background-color);
 }
 .modal-delete-content h6{
     font-weight: 700;
-    font-size: 16px;
+    font-size: 1rem;
     margin-bottom: .5rem;
 }
 .modal-delete-content span{
     font-weight: 400;
-    font-size: 16px;
+    font-size: 1rem;
     margin-bottom: 2rem;
 }
 .modal-delete-btn-wrapper {
     display: flex;
     width: 100%;
     height: 100%;
-    gap: 10px;
+    gap: .625rem;
 }
 .modal-delete-btn-wrapper button {
-    padding: 9px 14px;
+    padding: .5625rem .875rem;
     text-transform: uppercase;
     width: 50%;
-    height: 49px;
+    height: 3.0625rem;
 }
 .modal-delete-btn-cancel{
     color: #136FEE;
@@ -265,10 +270,11 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    padding: 1rem;
 }
 .menu-footer p {
     color: #3C3C3B;
-    font-family: IBM Plex Sans, sans-serif;
+    font-family: var(--chatbot-container-font-family-secondary);
     font-size: .875rem;
     font-style: normal;
     font-weight: 400;

--- a/flowise-embed/src/assets/menu.css
+++ b/flowise-embed/src/assets/menu.css
@@ -9,7 +9,7 @@
     position: relative;
     z-index: 1000;
 }
-.menu button {
+.menu .menu-opener-button {
     padding: 1.09375rem 0.625rem;
     position: fixed;
     top: 0;
@@ -100,6 +100,35 @@
 .menu-item p b {
     font-weight: 500;
 }
+.menu-history {
+    display: flex;
+    font-family: var(--chatbot-container-font-family, sans-serif);
+    height: 3.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 18px;
+    align-items: center;
+}
+.menu-history-date-label {
+    font-size: .75rem;
+    font-family: var(--chatbot-container-font-family, sans-serif);
+    color: #C4C6CF;
+}
+.menu-history-item-wrapper {
+    display: flex;
+    height: 2.5rem;
+    width: 100%;
+    padding: 1rem;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: .0313rem solid #FD9102;
+}
+.menu-history-item-wrapper span {
+    font-family: var(--chatbot-container-font-family, sans-serif);
+    font-size: .875rem;
+    font-weight: 500;
+    letter-spacing: .0094rem;
+}
 .menu-footer {
     display: flex;
     justify-content: center;
@@ -107,10 +136,11 @@
 }
 .menu-footer p {
     color: #3C3C3B;
-    font-size: 0.625rem;
+    font-family: IBM Plex Sans, sans-serif;
+    font-size: .875rem;
     font-style: normal;
     font-weight: 400;
-    line-height: 120%;
+    line-height: 1.05rem;
     letter-spacing: 0.03125rem;
 }
 .menu-footer p b {

--- a/flowise-embed/src/assets/menu.css
+++ b/flowise-embed/src/assets/menu.css
@@ -173,7 +173,7 @@
     height: 6.375rem;
     z-index: 1002;
     background-color: var(--menu-content-background-color);
-    box-shadow: 0 .25rem .25rem 0 #00000040;
+    box-shadow: 0 .25rem .25rem 0 rgba(0, 0, 0, 0.25);
 }
 .menu-history-option.bottom {
     top: 100%;

--- a/flowise-embed/src/assets/menu.css
+++ b/flowise-embed/src/assets/menu.css
@@ -65,6 +65,7 @@
     display: flex;
     flex-direction: column;
     gap: .3125rem;
+    overflow-y: scroll;
 }
 .menu-text{
     font-family: sans-serif;
@@ -115,14 +116,30 @@
     color: #C4C6CF;
 }
 .menu-history-item-wrapper {
+    position: relative;
+    width: 100%;
+    overflow-y: scroll;
+}
+.menu-history-item{
     display: flex;
+    padding: 1rem;
     position: relative;
     height: 2.5rem;
-    width: 100%;
-    padding: 1rem;
+    overflow: visible;
     justify-content: space-between;
     align-items: center;
     border-bottom: .0313rem solid #FD9102;
+}
+.menu-history-item-wrapper form {
+    height: 40px;
+    width: 100%;
+}
+.menu-history-item-wrapper form input {
+    font-family: var(--chatbot-container-font-family, sans-serif);
+    width: 100%;
+    height: 100%;
+    border: 2.5px solid #136FEE;
+    padding: 0 15px;
 }
 .menu-history-item-wrapper span {
     font-family: var(--chatbot-container-font-family, sans-serif);
@@ -132,14 +149,22 @@
 }
 .menu-history-option{
     position: absolute;
-    bottom: 2.2rem;
     border-radius: .3125rem;
-    right: 0;
+
     padding: 3px 9px;
     width: 10.375rem;
     height: 6.375rem;
+    z-index: 1002;
     background-color: #ECECEC;
     box-shadow: 0px 4px 4px 0px #00000040;
+}
+.menu-history-option.bottom {
+    top: 100%;
+    right: 0;
+}
+.menu-history-option.top {
+    bottom: 100%;
+    right: 0;
 }
 .menu-history-option-wrapper{
     display: flex;

--- a/flowise-embed/src/components/icons/DotsHorizontal.tsx
+++ b/flowise-embed/src/components/icons/DotsHorizontal.tsx
@@ -1,0 +1,5 @@
+export const DotsHorizontal = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+    <path fill="#272727" d="M16 12a2 2 0 1 1 4 0 2 2 0 0 1-4 0m-6 0a2 2 0 1 1 4 0 2 2 0 0 1-4 0m-6 0a2 2 0 1 1 4 0 2 2 0 0 1-4 0"></path>
+  </svg>
+);

--- a/flowise-embed/src/components/icons/DotsHorizontal.tsx
+++ b/flowise-embed/src/components/icons/DotsHorizontal.tsx
@@ -1,5 +1,5 @@
 export const DotsHorizontal = () => (
   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
-    <path fill="#272727" d="M16 12a2 2 0 1 1 4 0 2 2 0 0 1-4 0m-6 0a2 2 0 1 1 4 0 2 2 0 0 1-4 0m-6 0a2 2 0 1 1 4 0 2 2 0 0 1-4 0"></path>
+    <path fill="#272727" d="M16 12a2 2 0 1 1 4 0 2 2 0 0 1-4 0m-6 0a2 2 0 1 1 4 0 2 2 0 0 1-4 0m-6 0a2 2 0 1 1 4 0 2 2 0 0 1-4 0" />
   </svg>
 );

--- a/flowise-embed/src/components/icons/PenEditIcon.tsx
+++ b/flowise-embed/src/components/icons/PenEditIcon.tsx
@@ -1,0 +1,10 @@
+import { JSX } from 'solid-js/jsx-runtime';
+const defaultButtonColor = '#272727';
+export const PenEditIcon = (props: JSX.SvgSVGAttributes<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} fill="none" {...props}>
+    <path
+      fill={props.color ?? defaultButtonColor}
+      d="M20.71 7.04c.39-.39.39-1.04 0-1.41l-2.34-2.34c-.37-.39-1.02-.39-1.41 0l-1.84 1.83 3.75 3.75M3 17.25V21h3.75L17.81 9.93l-3.75-3.75L3 17.25Z"
+    />
+  </svg>
+);

--- a/flowise-embed/src/components/icons/index.ts
+++ b/flowise-embed/src/components/icons/index.ts
@@ -11,3 +11,4 @@ export * from './XIcon';
 export * from './TickIcon';
 export * from './AttachmentIcon';
 export * from './SparklesIcon';
+export * from './DotsHorizontal';

--- a/flowise-embed/src/components/icons/index.ts
+++ b/flowise-embed/src/components/icons/index.ts
@@ -12,3 +12,4 @@ export * from './TickIcon';
 export * from './AttachmentIcon';
 export * from './SparklesIcon';
 export * from './DotsHorizontal';
+export * from './PenEditIcon';

--- a/flowise-embed/src/features/menu/components/DeleteModal.tsx
+++ b/flowise-embed/src/features/menu/components/DeleteModal.tsx
@@ -1,0 +1,33 @@
+import { Show } from 'solid-js';
+
+type DeleteModalProps = {
+  chatName: string;
+  isOpen: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+const DeleteModal = (props: DeleteModalProps) => {
+  return (
+    <Show when={props.isOpen}>
+      <div class="modal-delete">
+        <div class="modal-delete-wrapper">
+          <div class="modal-delete-content">
+            <h6>Excluir Chat</h6>
+            <span>Tem certeza que deseja excluir {props.chatName}? Essa é uma ação permanente</span>
+            <div class="modal-delete-btn-wrapper">
+              <button type="button" class="modal-delete-btn-cancel" onClick={() => props.onCancel()}>
+                cancelar
+              </button>
+              <button class="modal-delete-btn-delete" onClick={() => props.onConfirm()}>
+                excluir
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+};
+
+export default DeleteModal;

--- a/flowise-embed/src/features/menu/components/DeleteModal.tsx
+++ b/flowise-embed/src/features/menu/components/DeleteModal.tsx
@@ -1,10 +1,11 @@
 import { Show } from 'solid-js';
+import { messageUtils } from '../../../utils/messageUtils';
 
 type DeleteModalProps = {
   chatName: string;
   isOpen: boolean;
   onCancel: () => void;
-  onConfirm: () => void;
+  onConfirm: (chatId: string) => void;
 };
 
 const DeleteModal = (props: DeleteModalProps) => {
@@ -14,13 +15,13 @@ const DeleteModal = (props: DeleteModalProps) => {
         <div class="modal-delete-wrapper">
           <div class="modal-delete-content">
             <h6>Excluir Chat</h6>
-            <span>Tem certeza que deseja excluir {props.chatName}? Essa é uma ação permanente</span>
+            <span>{messageUtils.DELETE_CONFIRMATION(props.chatName)}</span>
             <div class="modal-delete-btn-wrapper">
               <button type="button" class="modal-delete-btn-cancel" onClick={() => props.onCancel()}>
-                cancelar
+                {messageUtils.CANCEL_BUTTON}
               </button>
-              <button class="modal-delete-btn-delete" onClick={() => props.onConfirm()}>
-                excluir
+              <button class="modal-delete-btn-delete" onClick={() => props.onConfirm(props.chatName)}>
+                {messageUtils.DELETE_BUTTON}
               </button>
             </div>
           </div>

--- a/flowise-embed/src/features/menu/components/Menu.tsx
+++ b/flowise-embed/src/features/menu/components/Menu.tsx
@@ -3,7 +3,7 @@ import styles from '../../../assets/menu.css';
 import { MenuButton } from './MenuButton';
 import { MenuItem, MenuItemProps } from './MenuItem';
 import { LogoInterseas } from '@/components/icons/LogoInterseas';
-import { XIcon, DotsHorizontal } from '@/components/icons';
+import { XIcon, DotsHorizontal, TrashIcon, PenEditIcon } from '@/components/icons';
 import DocumentsDBService from '@/service/documentsDBService';
 
 const documentService = new DocumentsDBService();
@@ -14,6 +14,9 @@ export interface MenuProps {
 }
 export const Menu = (props: MenuProps) => {
   const [open, setOpen] = createSignal(false);
+  const [openMenuOptions, setOpenMenuOptions] = createSignal<boolean>(false);
+  const [openDeleteModal, setIsOpenDeleteModal] = createSignal<boolean>(false);
+  const [isEditing, setIsEditing] = createSignal<boolean>(false);
   const [currentFlow, setCurrentFLow] = createSignal(localStorage.getItem('currentFlow') || props.currentFlow);
 
   const handleClick = (flow: string) => {
@@ -21,6 +24,18 @@ export const Menu = (props: MenuProps) => {
     localStorage.setItem('currentFlow', flow);
   };
 
+  const toggleMenuOptions = () => {
+    setOpenMenuOptions(!openMenuOptions());
+  };
+
+  const toggleEditMode = () => {
+    setOpenMenuOptions(false);
+    setIsEditing(!isEditing());
+  };
+  const handleDeleteClick = () => {
+    setIsOpenDeleteModal(!openDeleteModal());
+    setOpenMenuOptions(false);
+  };
   return (
     <>
       <style>{styles}</style>
@@ -45,10 +60,38 @@ export const Menu = (props: MenuProps) => {
                 {/* <button>+Novo Chat</button> */}
                 <span class="menu-history-date-label">Hoje</span>
                 <div class="menu-history-item-wrapper">
-                  <span>Título da conversa 1</span>
-                  <button class="menu-history-button">
+                  {!isEditing() ? (
+                    <span>Título da conversa 1</span>
+                  ) : (
+                    <form
+                      onSubmit={() => {
+                        console.log('editou'), setIsEditing(false);
+                      }}
+                    >
+                      <input type="text" name="chatNameField" id="chatName" />
+                    </form>
+                  )}
+                  <button class="menu-history-button" onClick={() => toggleMenuOptions()}>
                     <DotsHorizontal />
                   </button>
+                  {openMenuOptions() && (
+                    <div class="menu-history-option">
+                      <div class="menu-history-option-wrapper">
+                        <div class="menu-history-option-edit">
+                          <button onClick={() => toggleEditMode()}>
+                            <PenEditIcon />
+                            Renomear chat
+                          </button>
+                        </div>
+                        <div class="menu-history-option-delete">
+                          <button onClick={() => handleDeleteClick()}>
+                            <TrashIcon color="#E41D1D" />
+                            Excluir
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  )}
                 </div>
               </div>
               <div class="menu-footer">
@@ -56,13 +99,29 @@ export const Menu = (props: MenuProps) => {
                   Powered By <b>StartSe</b>
                 </p>
               </div>
+              <div class="menu-overlay" onClick={() => setOpen(false)} />
             </div>
-            <div class="menu-overlay" onClick={() => setOpen(false)} />
           </div>
         ) : (
           <MenuButton fillColor={props.fillColor} onClick={() => setOpen(true)} />
         )}
       </div>
+      {openDeleteModal() ? (
+        <div class="modal-delete">
+          <div class="modal-delete-wrapper">
+            <div class="modal-delete-content">
+              <h6>Excluir Chat</h6>
+              <span>Tem certeza que deseja excluir [nome do chat]? Essa é uma ação permanente</span>
+              <div class="modal-delete-btn-wrapper">
+                <button type="button" class="modal-delete-btn-cancel" onClick={() => setIsOpenDeleteModal(false)}>
+                  cancelar
+                </button>
+                <button class="modal-delete-btn-delete">excluir</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </>
   );
 };

--- a/flowise-embed/src/features/menu/components/Menu.tsx
+++ b/flowise-embed/src/features/menu/components/Menu.tsx
@@ -1,4 +1,4 @@
-import { For, createSignal } from 'solid-js';
+import { For, createEffect, createResource, createSignal } from 'solid-js';
 import styles from '../../../assets/menu.css';
 import { MenuButton } from './MenuButton';
 import { MenuItem, MenuItemProps } from './MenuItem';
@@ -12,13 +12,25 @@ export interface MenuProps {
   items: MenuItemProps[];
   fillColor?: string;
 }
+interface ChatItem {
+  agent_flow: string;
+  chat_name: string | null;
+  created_at: string;
+  id: string;
+  updated_at: string | null;
+}
 export const Menu = (props: MenuProps) => {
   const [open, setOpen] = createSignal(false);
   const [openMenuOptions, setOpenMenuOptions] = createSignal<boolean>(false);
   const [openDeleteModal, setIsOpenDeleteModal] = createSignal<boolean>(false);
   const [isEditing, setIsEditing] = createSignal<boolean>(false);
   const [currentFlow, setCurrentFLow] = createSignal(localStorage.getItem('currentFlow') || props.currentFlow);
+  const [chatItems, setChatItems] = createSignal<ChatItem[]>([]);
 
+  createEffect(async () => {
+    const data = await documentService.getChatIdsByFlow(currentFlow());
+    setChatItems(data);
+  });
   const handleClick = (flow: string) => {
     setCurrentFLow(flow);
     localStorage.setItem('currentFlow', flow);
@@ -35,6 +47,14 @@ export const Menu = (props: MenuProps) => {
   const handleDeleteClick = () => {
     setIsOpenDeleteModal(!openDeleteModal());
     setOpenMenuOptions(false);
+  };
+  const formatDateChat = (item: ChatItem) => {
+    if (item.chat_name) {
+      return item.chat_name;
+    } else {
+      const date = new Date(item.created_at);
+      return `Sem título - ${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+    }
   };
   return (
     <>
@@ -61,7 +81,16 @@ export const Menu = (props: MenuProps) => {
                 <span class="menu-history-date-label">Hoje</span>
                 <div class="menu-history-item-wrapper">
                   {!isEditing() ? (
-                    <span>Título da conversa 1</span>
+                    <For each={chatItems()}>
+                      {(item) => (
+                        <div class="menu-history-item">
+                          <span>{formatDateChat(item)}</span>
+                          <button class="menu-history-button" onClick={() => toggleMenuOptions()}>
+                            <DotsHorizontal />
+                          </button>
+                        </div>
+                      )}
+                    </For>
                   ) : (
                     <form
                       onSubmit={() => {
@@ -71,9 +100,6 @@ export const Menu = (props: MenuProps) => {
                       <input type="text" name="chatNameField" id="chatName" />
                     </form>
                   )}
-                  <button class="menu-history-button" onClick={() => toggleMenuOptions()}>
-                    <DotsHorizontal />
-                  </button>
                   {openMenuOptions() && (
                     <div class="menu-history-option">
                       <div class="menu-history-option-wrapper">

--- a/flowise-embed/src/features/menu/components/Menu.tsx
+++ b/flowise-embed/src/features/menu/components/Menu.tsx
@@ -6,7 +6,7 @@ import { LogoInterseas } from '@/components/icons/LogoInterseas';
 import { XIcon, DotsHorizontal, TrashIcon, PenEditIcon } from '@/components/icons';
 import DocumentsDBService from '@/service/documentsDBService';
 import DeleteModal from './DeleteModal';
-import { group } from 'console';
+import { DEFAULT_CHAT_NAME } from '@/utils/messageUtils';
 
 const documentService = new DocumentsDBService();
 export interface MenuProps {
@@ -28,7 +28,6 @@ export const Menu = (props: MenuProps) => {
   const [groupedChatItems, setGroupedChatItems] = createSignal<object>({ groups: {} });
   const [editingChatId, setEditingChatId] = createSignal<string | null>(null);
   const [openMenuOptions, setOpenMenuOptions] = createSignal<string | null>(null);
-  const [isEditing, setIsEditing] = createSignal<boolean>(false);
   const [inputValue, setInputValue] = createSignal<string>('');
   const [modalPosition, setModalPosition] = createSignal<'top' | 'bottom'>('bottom');
   const [selectedChatId, setSelectedChatId] = createSignal<string | null>(null);
@@ -64,7 +63,6 @@ export const Menu = (props: MenuProps) => {
   };
 
   const startEditing = (chatId: string) => {
-    setIsEditing(true);
     setEditingChatId(chatId);
     setOpenMenuOptions(null);
   };
@@ -101,7 +99,7 @@ export const Menu = (props: MenuProps) => {
       return item.chatName;
     } else {
       const date = new Date(item.createdAt);
-      return `Sem título - ${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+      return DEFAULT_CHAT_NAME(date);
     }
   };
 
@@ -116,10 +114,10 @@ export const Menu = (props: MenuProps) => {
 
     function adjustDateToBrazilianTime(date: Date): Date {
       const brazilTimezoneOffset = -180;
-      const milisecondsInAMinute = 60000;
+      const millisecondsInAMinute = 60000;
       const localTimezoneOffset = date.getTimezoneOffset();
       const offsetDifference = brazilTimezoneOffset - localTimezoneOffset;
-      return new Date(date.getTime() + offsetDifference * milisecondsInAMinute);
+      return new Date(date.getTime() + offsetDifference * millisecondsInAMinute);
     }
 
     // Sort chatItems by created_at in descending order
@@ -128,7 +126,7 @@ export const Menu = (props: MenuProps) => {
     let currentGroupIndex = 0;
 
     chatItems.forEach((item) => {
-      const milisecondsInASecond = 1000;
+      const millisecondsInASecond = 1000;
       const hoursInADay = 24;
       const secondsInMinutes = 60;
       const date = adjustDateToBrazilianTime(new Date(item.createdAt));
@@ -138,7 +136,7 @@ export const Menu = (props: MenuProps) => {
       const nowOnly = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 
       const diffTime = Math.abs(nowOnly.getTime() - dateOnly.getTime());
-      const diffDays = Math.ceil(diffTime / (milisecondsInASecond * secondsInMinutes * secondsInMinutes * hoursInADay));
+      const diffDays = Math.ceil(diffTime / (millisecondsInASecond * secondsInMinutes * secondsInMinutes * hoursInADay));
 
       for (let groupIndex = currentGroupIndex; groupIndex < groups.length; groupIndex++) {
         const currentGroup = groups[groupIndex];
@@ -175,7 +173,6 @@ export const Menu = (props: MenuProps) => {
       await documentService.updateChatName(chatId, inputValue());
       fetchChatIds();
     }
-    setIsEditing(false);
     setEditingChatId(null);
   };
 
@@ -215,7 +212,7 @@ export const Menu = (props: MenuProps) => {
                               let buttonRef: HTMLButtonElement | null = null;
                               return (
                                 <div class="menu-history-item">
-                                  {editingChatId() === item.id && isEditing() ? (
+                                  {editingChatId() === item.id && editingChatId() !== null ? (
                                     <form onSubmit={(e) => handleEditSubmit(e, item.id)}>
                                       <input type="text" name="chat-name" id={item.id} value={formatDateChat(item)} onInput={handleInputChange} />
                                     </form>

--- a/flowise-embed/src/features/menu/components/Menu.tsx
+++ b/flowise-embed/src/features/menu/components/Menu.tsx
@@ -1,4 +1,4 @@
-import { For, createEffect, createResource, createSignal } from 'solid-js';
+import { For, createEffect, createSignal } from 'solid-js';
 import styles from '../../../assets/menu.css';
 import { MenuButton } from './MenuButton';
 import { MenuItem, MenuItemProps } from './MenuItem';
@@ -21,33 +21,55 @@ interface ChatItem {
 }
 export const Menu = (props: MenuProps) => {
   const [open, setOpen] = createSignal(false);
-  const [openMenuOptions, setOpenMenuOptions] = createSignal<boolean>(false);
   const [openDeleteModal, setIsOpenDeleteModal] = createSignal<boolean>(false);
-  const [isEditing, setIsEditing] = createSignal<boolean>(false);
   const [currentFlow, setCurrentFLow] = createSignal(localStorage.getItem('currentFlow') || props.currentFlow);
   const [chatItems, setChatItems] = createSignal<ChatItem[]>([]);
+  const [editingChatId, setEditingChatId] = createSignal<string | null>(null);
+  const [openMenuOptions, setOpenMenuOptions] = createSignal<string | null>(null);
+  const [isEditing, setIsEditing] = createSignal<boolean>(false);
+  const [modalPosition, setModalPosition] = createSignal<'top' | 'bottom'>('bottom');
 
-  createEffect(async () => {
-    const data = await documentService.getChatIdsByFlow(currentFlow());
-    setChatItems(data);
-  });
   const handleClick = (flow: string) => {
     setCurrentFLow(flow);
     localStorage.setItem('currentFlow', flow);
   };
 
-  const toggleMenuOptions = () => {
-    setOpenMenuOptions(!openMenuOptions());
+  const toggleMenuOptions = (chatId: string, buttonRef: HTMLButtonElement) => {
+    const isOpen = openMenuOptions() === chatId;
+    setOpenMenuOptions(isOpen ? null : chatId);
+    setEditingChatId(null);
+
+    if (!isOpen) {
+      const buttonRect = buttonRef.getBoundingClientRect();
+      const spaceBelow = window.innerHeight - buttonRect.bottom;
+      const spaceAbove = buttonRect.top;
+
+      if (spaceBelow < 200 && spaceAbove > 200) {
+        setModalPosition('top');
+      } else {
+        setModalPosition('bottom');
+      }
+    }
   };
 
-  const toggleEditMode = () => {
-    setOpenMenuOptions(false);
-    setIsEditing(!isEditing());
+  const startEditing = (chatId: string) => {
+    setIsEditing(true);
+    setEditingChatId(chatId);
+    setOpenMenuOptions(null);
   };
+
+  const handleEditSubmit = (event: Event, chatId: string) => {
+    event.preventDefault();
+    console.log('editou');
+    setIsEditing(false);
+    setEditingChatId(null);
+  };
+
   const handleDeleteClick = () => {
     setIsOpenDeleteModal(!openDeleteModal());
-    setOpenMenuOptions(false);
+    setOpenMenuOptions(null);
   };
+
   const formatDateChat = (item: ChatItem) => {
     if (item.chat_name) {
       return item.chat_name;
@@ -56,6 +78,17 @@ export const Menu = (props: MenuProps) => {
       return `Sem título - ${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
     }
   };
+
+  createEffect(() => {
+    const fetchChatIds = async () => {
+      const data = await documentService.getChatIdsByFlow(currentFlow());
+      if (data && Array.isArray(data)) {
+        setChatItems(data as ChatItem[]);
+      }
+    };
+    fetchChatIds();
+  });
+
   return (
     <>
       <style>{styles}</style>
@@ -80,44 +113,49 @@ export const Menu = (props: MenuProps) => {
                 {/* <button>+Novo Chat</button> */}
                 <span class="menu-history-date-label">Hoje</span>
                 <div class="menu-history-item-wrapper">
-                  {!isEditing() ? (
-                    <For each={chatItems()}>
-                      {(item) => (
+                  <For each={chatItems()}>
+                    {(item) => {
+                      let buttonRef: HTMLButtonElement | null = null;
+                      return (
                         <div class="menu-history-item">
-                          <span>{formatDateChat(item)}</span>
-                          <button class="menu-history-button" onClick={() => toggleMenuOptions()}>
-                            <DotsHorizontal />
-                          </button>
+                          {editingChatId() === item.id && isEditing() ? (
+                            <form onSubmit={(e) => handleEditSubmit(e, item.id)}>
+                              <input type="text" name="chatNameField" id={item.id} value={formatDateChat(item)} />
+                            </form>
+                          ) : (
+                            <>
+                              <span>{formatDateChat(item)}</span>
+                              <button
+                                class="menu-history-button"
+                                ref={(el) => (buttonRef = el)}
+                                onClick={() => toggleMenuOptions(item.id, buttonRef!)}
+                              >
+                                <DotsHorizontal />
+                              </button>
+                            </>
+                          )}
+                          {openMenuOptions() === item.id && (
+                            <div class={`menu-history-option ${modalPosition()}`}>
+                              <div class="menu-history-option-wrapper">
+                                <div class="menu-history-option-edit">
+                                  <button onClick={() => startEditing(item.id)}>
+                                    <PenEditIcon />
+                                    Renomear chat
+                                  </button>
+                                </div>
+                                <div class="menu-history-option-delete">
+                                  <button onClick={() => handleDeleteClick()}>
+                                    <TrashIcon color="#e41d1d" />
+                                    Excluir chat
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          )}
                         </div>
-                      )}
-                    </For>
-                  ) : (
-                    <form
-                      onSubmit={() => {
-                        console.log('editou'), setIsEditing(false);
-                      }}
-                    >
-                      <input type="text" name="chatNameField" id="chatName" />
-                    </form>
-                  )}
-                  {openMenuOptions() && (
-                    <div class="menu-history-option">
-                      <div class="menu-history-option-wrapper">
-                        <div class="menu-history-option-edit">
-                          <button onClick={() => toggleEditMode()}>
-                            <PenEditIcon />
-                            Renomear chat
-                          </button>
-                        </div>
-                        <div class="menu-history-option-delete">
-                          <button onClick={() => handleDeleteClick()}>
-                            <TrashIcon color="#E41D1D" />
-                            Excluir
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  )}
+                      );
+                    }}
+                  </For>
                 </div>
               </div>
               <div class="menu-footer">

--- a/flowise-embed/src/features/menu/components/Menu.tsx
+++ b/flowise-embed/src/features/menu/components/Menu.tsx
@@ -3,7 +3,7 @@ import styles from '../../../assets/menu.css';
 import { MenuButton } from './MenuButton';
 import { MenuItem, MenuItemProps } from './MenuItem';
 import { LogoInterseas } from '@/components/icons/LogoInterseas';
-import { XIcon } from '@/components/icons/XIcon';
+import { XIcon, DotsHorizontal } from '@/components/icons';
 import DocumentsDBService from '@/service/documentsDBService';
 
 const documentService = new DocumentsDBService();
@@ -41,6 +41,15 @@ export const Menu = (props: MenuProps) => {
                 <For each={props.items}>
                   {(item) => <MenuItem {...item} selected={item.flow === currentFlow()} onClick={() => handleClick(item.flow)} />}
                 </For>
+                <div class="menu-history">Histórico de chats - Análise Crítica</div>
+                {/* <button>+Novo Chat</button> */}
+                <span class="menu-history-date-label">Hoje</span>
+                <div class="menu-history-item-wrapper">
+                  <span>Título da conversa 1</span>
+                  <button class="menu-history-button">
+                    <DotsHorizontal />
+                  </button>
+                </div>
               </div>
               <div class="menu-footer">
                 <p>

--- a/flowise-embed/src/features/menu/components/Menu.tsx
+++ b/flowise-embed/src/features/menu/components/Menu.tsx
@@ -212,7 +212,7 @@ export const Menu = (props: MenuProps) => {
                               let buttonRef: HTMLButtonElement | null = null;
                               return (
                                 <div class="menu-history-item">
-                                  {editingChatId() === item.id && editingChatId() !== null ? (
+                                  {!!editingChatId() && editingChatId() === item.id ? (
                                     <form onSubmit={(e) => handleEditSubmit(e, item.id)}>
                                       <input type="text" name="chat-name" id={item.id} value={formatDateChat(item)} onInput={handleInputChange} />
                                     </form>

--- a/flowise-embed/src/features/menu/components/Menu.tsx
+++ b/flowise-embed/src/features/menu/components/Menu.tsx
@@ -24,14 +24,23 @@ export const Menu = (props: MenuProps) => {
   const [openDeleteModal, setIsOpenDeleteModal] = createSignal<boolean>(false);
   const [currentFlow, setCurrentFLow] = createSignal(localStorage.getItem('currentFlow') || props.currentFlow);
   const [chatItems, setChatItems] = createSignal<ChatItem[]>([]);
+  const [groupedChatItems, setGroupedChatItems] = createSignal<{ groups: any; labels: any }>({ groups: {}, labels: {} });
   const [editingChatId, setEditingChatId] = createSignal<string | null>(null);
   const [openMenuOptions, setOpenMenuOptions] = createSignal<string | null>(null);
   const [isEditing, setIsEditing] = createSignal<boolean>(false);
+  const [inputValue, setInputValue] = createSignal<string>('');
   const [modalPosition, setModalPosition] = createSignal<'top' | 'bottom'>('bottom');
+  const [selectedChatId, setSelectedChatId] = createSignal<string | null>(null);
+  const [selectedChatName, setSelectedChatName] = createSignal<string | null>(null);
 
   const handleClick = (flow: string) => {
     setCurrentFLow(flow);
     localStorage.setItem('currentFlow', flow);
+  };
+
+  const handleInputChange = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    setInputValue(target.value);
   };
 
   const toggleMenuOptions = (chatId: string, buttonRef: HTMLButtonElement) => {
@@ -58,16 +67,29 @@ export const Menu = (props: MenuProps) => {
     setOpenMenuOptions(null);
   };
 
-  const handleEditSubmit = (event: Event, chatId: string) => {
-    event.preventDefault();
-    console.log('editou');
-    setIsEditing(false);
-    setEditingChatId(null);
+  const handleOpenDeleteModal = (chatId: string, chatName: string) => {
+    setSelectedChatId(chatId);
+    setSelectedChatName(chatName);
+    setIsOpenDeleteModal(true);
+    setOpenMenuOptions(null);
   };
 
-  const handleDeleteClick = () => {
-    setIsOpenDeleteModal(!openDeleteModal());
-    setOpenMenuOptions(null);
+  const handleConfirmDelete = async () => {
+    setIsOpenDeleteModal(false);
+    if (selectedChatId()) {
+      await documentService.deleteChat(selectedChatId() as string);
+      fetchChatIds();
+    }
+  };
+
+  const getChatHistoryTitle = () => {
+    if (currentFlow() === 'compliance') {
+      return 'Análise de Compliance';
+    } else if (currentFlow() === 'critical_analysis') {
+      return 'Análise Crítica';
+    } else {
+      return 'Estimativa de Custos';
+    }
   };
 
   const formatDateChat = (item: ChatItem) => {
@@ -79,13 +101,65 @@ export const Menu = (props: MenuProps) => {
     }
   };
 
-  createEffect(() => {
-    const fetchChatIds = async () => {
-      const data = await documentService.getChatIdsByFlow(currentFlow());
-      if (data && Array.isArray(data)) {
-        setChatItems(data as ChatItem[]);
-      }
+  const preprocessChatItems = (chatItems: ChatItem[]) => {
+    const groups = {
+      today: [] as ChatItem[],
+      yesterday: [] as ChatItem[],
+      lastWeek: [] as ChatItem[],
+      lastMonth: [] as ChatItem[],
+      older: [] as ChatItem[],
     };
+    const labels = {
+      today: 'Hoje',
+      yesterday: 'Ontem',
+      lastWeek: 'Últimos 7 dias',
+      lastMonth: 'Últimos 30 dias',
+      older: '30 dias ou mais atrás',
+    };
+
+    chatItems.forEach((item) => {
+      const date = new Date(item.created_at);
+      const now = new Date();
+      const diffTime = Math.abs(now.getTime() - date.getTime());
+      const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+      if (diffDays === 0) {
+        groups.today.push(item);
+      } else if (diffDays === 1) {
+        groups.yesterday.push(item);
+      } else if (diffDays <= 7) {
+        groups.lastWeek.push(item);
+      } else if (diffDays <= 30) {
+        groups.lastMonth.push(item);
+      } else {
+        groups.older.push(item);
+      }
+    });
+
+    return { groups, labels };
+  };
+
+  const fetchChatIds = async () => {
+    const data = await documentService.getChatIdsByFlow(currentFlow());
+    if (data && Array.isArray(data)) {
+      setChatItems(data as ChatItem[]);
+      setGroupedChatItems(preprocessChatItems(data as ChatItem[]));
+    }
+  };
+
+  const handleEditSubmit = async (event: Event, chatId: string) => {
+    event.preventDefault();
+    if (chatId.length > 0) {
+      await documentService.updateChatName(chatId, inputValue());
+      fetchChatIds();
+    } else {
+      console.log('Chat ID inválido');
+    }
+    setIsEditing(false);
+    setEditingChatId(null);
+  };
+
+  createEffect(() => {
     fetchChatIds();
   });
 
@@ -109,52 +183,60 @@ export const Menu = (props: MenuProps) => {
                 <For each={props.items}>
                   {(item) => <MenuItem {...item} selected={item.flow === currentFlow()} onClick={() => handleClick(item.flow)} />}
                 </For>
-                <div class="menu-history">Histórico de chats - Análise Crítica</div>
+                <div class="menu-history">Histórico de chats - {getChatHistoryTitle()} </div>
                 {/* <button>+Novo Chat</button> */}
-                <span class="menu-history-date-label">Hoje</span>
                 <div class="menu-history-item-wrapper">
-                  <For each={chatItems()}>
-                    {(item) => {
-                      let buttonRef: HTMLButtonElement | null = null;
-                      return (
-                        <div class="menu-history-item">
-                          {editingChatId() === item.id && isEditing() ? (
-                            <form onSubmit={(e) => handleEditSubmit(e, item.id)}>
-                              <input type="text" name="chatNameField" id={item.id} value={formatDateChat(item)} />
-                            </form>
-                          ) : (
-                            <>
-                              <span>{formatDateChat(item)}</span>
-                              <button
-                                class="menu-history-button"
-                                ref={(el) => (buttonRef = el)}
-                                onClick={() => toggleMenuOptions(item.id, buttonRef!)}
-                              >
-                                <DotsHorizontal />
-                              </button>
-                            </>
-                          )}
-                          {openMenuOptions() === item.id && (
-                            <div class={`menu-history-option ${modalPosition()}`}>
-                              <div class="menu-history-option-wrapper">
-                                <div class="menu-history-option-edit">
-                                  <button onClick={() => startEditing(item.id)}>
-                                    <PenEditIcon />
-                                    Renomear chat
-                                  </button>
+                  <For each={Object.entries(groupedChatItems().groups)}>
+                    {([key, items]) =>
+                      (items as ChatItem[]).length > 0 && (
+                        <div class="menu-history-item-group">
+                          <span class="menu-history-date-label">{groupedChatItems().labels[key]}</span>
+                          <For each={items as ChatItem[]}>
+                            {(item) => {
+                              let buttonRef: HTMLButtonElement | null = null;
+                              return (
+                                <div class="menu-history-item">
+                                  {editingChatId() === item.id && isEditing() ? (
+                                    <form onSubmit={(e) => handleEditSubmit(e, item.id)}>
+                                      <input type="text" name="chatNameField" id={item.id} value={formatDateChat(item)} onInput={handleInputChange} />
+                                    </form>
+                                  ) : (
+                                    <>
+                                      <span>{formatDateChat(item)}</span>
+                                      <button
+                                        class="menu-history-button"
+                                        ref={(element) => (buttonRef = element)}
+                                        onClick={() => buttonRef && toggleMenuOptions(item.id, buttonRef)}
+                                      >
+                                        <DotsHorizontal />
+                                      </button>
+                                    </>
+                                  )}
+                                  {openMenuOptions() === item.id && (
+                                    <div class={`menu-history-option ${modalPosition()}`}>
+                                      <div class="menu-history-option-wrapper">
+                                        <div class="menu-history-option-edit">
+                                          <button onClick={() => startEditing(item.id)}>
+                                            <PenEditIcon />
+                                            Renomear chat
+                                          </button>
+                                        </div>
+                                        <div class="menu-history-option-delete">
+                                          <button onClick={() => handleOpenDeleteModal(item.id, formatDateChat(item))}>
+                                            <TrashIcon color="#e41d1d" />
+                                            Excluir chat
+                                          </button>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  )}
                                 </div>
-                                <div class="menu-history-option-delete">
-                                  <button onClick={() => handleDeleteClick()}>
-                                    <TrashIcon color="#e41d1d" />
-                                    Excluir chat
-                                  </button>
-                                </div>
-                              </div>
-                            </div>
-                          )}
+                              );
+                            }}
+                          </For>
                         </div>
-                      );
-                    }}
+                      )
+                    }
                   </For>
                 </div>
               </div>
@@ -175,12 +257,14 @@ export const Menu = (props: MenuProps) => {
           <div class="modal-delete-wrapper">
             <div class="modal-delete-content">
               <h6>Excluir Chat</h6>
-              <span>Tem certeza que deseja excluir [nome do chat]? Essa é uma ação permanente</span>
+              <span>Tem certeza que deseja excluir {selectedChatName()}? Essa é uma ação permanente</span>
               <div class="modal-delete-btn-wrapper">
                 <button type="button" class="modal-delete-btn-cancel" onClick={() => setIsOpenDeleteModal(false)}>
                   cancelar
                 </button>
-                <button class="modal-delete-btn-delete">excluir</button>
+                <button class="modal-delete-btn-delete" onClick={() => handleConfirmDelete()}>
+                  excluir
+                </button>
               </div>
             </div>
           </div>

--- a/flowise-embed/src/features/menu/components/Menu.tsx
+++ b/flowise-embed/src/features/menu/components/Menu.tsx
@@ -6,6 +6,7 @@ import { LogoInterseas } from '@/components/icons/LogoInterseas';
 import { XIcon, DotsHorizontal, TrashIcon, PenEditIcon } from '@/components/icons';
 import DocumentsDBService from '@/service/documentsDBService';
 import DeleteModal from './DeleteModal';
+import { group } from 'console';
 
 const documentService = new DocumentsDBService();
 export interface MenuProps {
@@ -14,20 +15,17 @@ export interface MenuProps {
   fillColor?: string;
 }
 interface ChatItem {
-  agent_flow: string;
-  chat_name: string | null;
-  created_at: string;
+  agentFlow: string;
+  chatName: string | null;
+  createdAt: string;
   id: string;
-  updated_at: string | null;
+  updatedAt: string | null;
 }
 export const Menu = (props: MenuProps) => {
   const [open, setOpen] = createSignal(false);
   const [openDeleteModal, setIsOpenDeleteModal] = createSignal<boolean>(false);
   const [currentFlow, setCurrentFLow] = createSignal(localStorage.getItem('currentFlow') || props.currentFlow);
-  const [groupedChatItems, setGroupedChatItems] = createSignal<{ groups: Record<string, ChatItem[]>; labels: Record<string, string> }>({
-    groups: {},
-    labels: {},
-  });
+  const [groupedChatItems, setGroupedChatItems] = createSignal<object>({ groups: {} });
   const [editingChatId, setEditingChatId] = createSignal<string | null>(null);
   const [openMenuOptions, setOpenMenuOptions] = createSignal<string | null>(null);
   const [isEditing, setIsEditing] = createSignal<boolean>(false);
@@ -55,8 +53,9 @@ export const Menu = (props: MenuProps) => {
       const buttonRect = buttonRef.getBoundingClientRect();
       const spaceBelow = window.innerHeight - buttonRect.bottom;
       const spaceAbove = buttonRect.top;
+      const minSpaceForModal = 200;
 
-      if (spaceBelow < 200 && spaceAbove > 200) {
+      if (spaceBelow < minSpaceForModal && spaceAbove > minSpaceForModal) {
         setModalPosition('top');
       } else {
         setModalPosition('bottom');
@@ -86,81 +85,87 @@ export const Menu = (props: MenuProps) => {
   };
 
   const getChatHistoryTitle = () => {
-    if (currentFlow() === 'compliance') {
-      return 'Análise de Compliance';
-    } else if (currentFlow() === 'critical_analysis') {
-      return 'Análise Crítica';
-    } else {
-      return 'Estimativa de Custos';
+    const flowTitleMapping = {
+      compliance: 'Análise de Compliance',
+      critical_analysis: 'Análise Crítica',
+    };
+    try {
+      return flowTitleMapping[currentFlow() as keyof typeof flowTitleMapping];
+    } catch (error) {
+      return '';
     }
   };
 
   const formatDateChat = (item: ChatItem) => {
-    if (item.chat_name) {
-      return item.chat_name;
+    if (item.chatName) {
+      return item.chatName;
     } else {
-      const date = new Date(item.created_at);
+      const date = new Date(item.createdAt);
       return `Sem título - ${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
     }
   };
 
-  const preprocessChatItems = (chatItems: ChatItem[]) => {
-    const groups = {
-      today: [] as ChatItem[],
-      yesterday: [] as ChatItem[],
-      lastWeek: [] as ChatItem[],
-      lastMonth: [] as ChatItem[],
-      older: [] as ChatItem[],
-    };
-    const labels = {
-      today: 'Hoje',
-      yesterday: 'Ontem',
-      lastWeek: 'Últimos 7 dias',
-      lastMonth: 'Últimos 30 dias',
-      older: '30 dias ou mais atrás',
-    };
+  const groupChatItemsByDate = (chatItems: ChatItem[]) => {
+    const groups = [
+      { label: 'Hoje', items: [] as ChatItem[], minDaysDiff: 0, maxDaysDiff: 0 },
+      { label: 'Ontem', items: [] as ChatItem[], minDaysDiff: 1, maxDaysDiff: 1 },
+      { label: 'Últimos 7 dias', items: [] as ChatItem[], minDaysDiff: 2, maxDaysDiff: 7 },
+      { label: 'Últimos 30 dias', items: [] as ChatItem[], minDaysDiff: 8, maxDaysDiff: 30 },
+      { label: 'Mais antigos', items: [] as ChatItem[], minDaysDiff: 31, maxDaysDiff: null },
+    ];
 
-    const adjustToBrazilTime = (date: Date) => {
-      // Manual adjustment for Brazil time zone (UTC-3)
-      const offset = -3 * 60; // UTC-3 in minutes
-      const utcDate = new Date(date.getTime() + date.getTimezoneOffset() * 60000);
-      return new Date(utcDate.getTime() + offset * 60000);
-    };
+    function adjustDateToBrazilianTime(date: Date): Date {
+      const brazilTimezoneOffset = -180;
+      const milisecondsInAMinute = 60000;
+      const localTimezoneOffset = date.getTimezoneOffset();
+      const offsetDifference = brazilTimezoneOffset - localTimezoneOffset;
+      return new Date(date.getTime() + offsetDifference * milisecondsInAMinute);
+    }
 
     // Sort chatItems by created_at in descending order
-    chatItems.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+    chatItems.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+    let currentGroupIndex = 0;
 
     chatItems.forEach((item) => {
-      const date = adjustToBrazilTime(new Date(item.created_at));
-      const now = adjustToBrazilTime(new Date());
+      const milisecondsInASecond = 1000;
+      const hoursInADay = 24;
+      const secondsInMinutes = 60;
+      const date = adjustDateToBrazilianTime(new Date(item.createdAt));
+      const now = adjustDateToBrazilianTime(new Date());
 
-      // Zero out hours, minutes, seconds, and milliseconds for day comparison
       const dateOnly = new Date(date.getFullYear(), date.getMonth(), date.getDate());
       const nowOnly = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 
       const diffTime = Math.abs(nowOnly.getTime() - dateOnly.getTime());
-      const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+      const diffDays = Math.ceil(diffTime / (milisecondsInASecond * secondsInMinutes * secondsInMinutes * hoursInADay));
 
-      if (diffDays === 0) {
-        groups.today.push(item);
-      } else if (diffDays === 1) {
-        groups.yesterday.push(item);
-      } else if (diffDays <= 7) {
-        groups.lastWeek.push(item);
-      } else if (diffDays <= 30) {
-        groups.lastMonth.push(item);
-      } else {
-        groups.older.push(item);
+      for (let groupIndex = currentGroupIndex; groupIndex < groups.length; groupIndex++) {
+        const currentGroup = groups[groupIndex];
+        if (
+          (currentGroup.minDaysDiff === null || diffDays >= currentGroup.minDaysDiff) &&
+          (currentGroup.maxDaysDiff === null || diffDays <= currentGroup.maxDaysDiff)
+        ) {
+          currentGroup.items.push(item);
+          return;
+        }
+        currentGroupIndex++;
       }
     });
-
-    return { groups, labels };
+    return groups;
   };
 
   const fetchChatIds = async () => {
     const data = await documentService.getChatIdsByFlow(currentFlow());
     if (data && Array.isArray(data)) {
-      setGroupedChatItems(preprocessChatItems(data as ChatItem[]));
+      const formatCamelCaseData = data.map((item) => ({
+        agentFlow: item.agent_flow,
+        chatName: item.chat_name,
+        createdAt: item.created_at,
+        id: item.id,
+        updatedAt: item.updated_at,
+      }));
+      setGroupedChatItems(groupChatItemsByDate(formatCamelCaseData as ChatItem[]));
     }
   };
 
@@ -199,21 +204,20 @@ export const Menu = (props: MenuProps) => {
                   {(item) => <MenuItem {...item} selected={item.flow === currentFlow()} onClick={() => handleClick(item.flow)} />}
                 </For>
                 <div class="menu-history">Histórico de chats - {getChatHistoryTitle()} </div>
-                {/* <button>+Novo Chat</button> */}
                 <div class="menu-history-item-wrapper">
-                  <For each={Object.entries(groupedChatItems().groups)}>
-                    {([key, items]) =>
-                      (items as ChatItem[]).length > 0 && (
-                        <div class="menu-history-item-group">
-                          <span class="menu-history-date-label">{groupedChatItems().labels[key]}</span>
-                          <For each={items as ChatItem[]}>
+                  <For each={Object.values(groupedChatItems())}>
+                    {(group) =>
+                      group.items.length > 0 && (
+                        <div class={`menu-history-item-group ${group.items.length < 5 ? 'min-height' : ''}`}>
+                          <span class="menu-history-date-label">{group.label}</span>
+                          <For each={group.items}>
                             {(item) => {
                               let buttonRef: HTMLButtonElement | null = null;
                               return (
                                 <div class="menu-history-item">
                                   {editingChatId() === item.id && isEditing() ? (
                                     <form onSubmit={(e) => handleEditSubmit(e, item.id)}>
-                                      <input type="text" name="chatNameField" id={item.id} value={formatDateChat(item)} onInput={handleInputChange} />
+                                      <input type="text" name="chat-name" id={item.id} value={formatDateChat(item)} onInput={handleInputChange} />
                                     </form>
                                   ) : (
                                     <>

--- a/flowise-embed/src/features/menu/components/Menu.tsx
+++ b/flowise-embed/src/features/menu/components/Menu.tsx
@@ -5,6 +5,7 @@ import { MenuItem, MenuItemProps } from './MenuItem';
 import { LogoInterseas } from '@/components/icons/LogoInterseas';
 import { XIcon, DotsHorizontal, TrashIcon, PenEditIcon } from '@/components/icons';
 import DocumentsDBService from '@/service/documentsDBService';
+import DeleteModal from './DeleteModal';
 
 const documentService = new DocumentsDBService();
 export interface MenuProps {
@@ -23,8 +24,10 @@ export const Menu = (props: MenuProps) => {
   const [open, setOpen] = createSignal(false);
   const [openDeleteModal, setIsOpenDeleteModal] = createSignal<boolean>(false);
   const [currentFlow, setCurrentFLow] = createSignal(localStorage.getItem('currentFlow') || props.currentFlow);
-  const [chatItems, setChatItems] = createSignal<ChatItem[]>([]);
-  const [groupedChatItems, setGroupedChatItems] = createSignal<{ groups: any; labels: any }>({ groups: {}, labels: {} });
+  const [groupedChatItems, setGroupedChatItems] = createSignal<{ groups: Record<string, ChatItem[]>; labels: Record<string, string> }>({
+    groups: {},
+    labels: {},
+  });
   const [editingChatId, setEditingChatId] = createSignal<string | null>(null);
   const [openMenuOptions, setOpenMenuOptions] = createSignal<string | null>(null);
   const [isEditing, setIsEditing] = createSignal<boolean>(false);
@@ -117,10 +120,25 @@ export const Menu = (props: MenuProps) => {
       older: '30 dias ou mais atrás',
     };
 
+    const adjustToBrazilTime = (date: Date) => {
+      // Manual adjustment for Brazil time zone (UTC-3)
+      const offset = -3 * 60; // UTC-3 in minutes
+      const utcDate = new Date(date.getTime() + date.getTimezoneOffset() * 60000);
+      return new Date(utcDate.getTime() + offset * 60000);
+    };
+
+    // Sort chatItems by created_at in descending order
+    chatItems.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+
     chatItems.forEach((item) => {
-      const date = new Date(item.created_at);
-      const now = new Date();
-      const diffTime = Math.abs(now.getTime() - date.getTime());
+      const date = adjustToBrazilTime(new Date(item.created_at));
+      const now = adjustToBrazilTime(new Date());
+
+      // Zero out hours, minutes, seconds, and milliseconds for day comparison
+      const dateOnly = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+      const nowOnly = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+      const diffTime = Math.abs(nowOnly.getTime() - dateOnly.getTime());
       const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
 
       if (diffDays === 0) {
@@ -142,7 +160,6 @@ export const Menu = (props: MenuProps) => {
   const fetchChatIds = async () => {
     const data = await documentService.getChatIdsByFlow(currentFlow());
     if (data && Array.isArray(data)) {
-      setChatItems(data as ChatItem[]);
       setGroupedChatItems(preprocessChatItems(data as ChatItem[]));
     }
   };
@@ -152,8 +169,6 @@ export const Menu = (props: MenuProps) => {
     if (chatId.length > 0) {
       await documentService.updateChatName(chatId, inputValue());
       fetchChatIds();
-    } else {
-      console.log('Chat ID inválido');
     }
     setIsEditing(false);
     setEditingChatId(null);
@@ -252,24 +267,12 @@ export const Menu = (props: MenuProps) => {
           <MenuButton fillColor={props.fillColor} onClick={() => setOpen(true)} />
         )}
       </div>
-      {openDeleteModal() ? (
-        <div class="modal-delete">
-          <div class="modal-delete-wrapper">
-            <div class="modal-delete-content">
-              <h6>Excluir Chat</h6>
-              <span>Tem certeza que deseja excluir {selectedChatName()}? Essa é uma ação permanente</span>
-              <div class="modal-delete-btn-wrapper">
-                <button type="button" class="modal-delete-btn-cancel" onClick={() => setIsOpenDeleteModal(false)}>
-                  cancelar
-                </button>
-                <button class="modal-delete-btn-delete" onClick={() => handleConfirmDelete()}>
-                  excluir
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      ) : null}
+      <DeleteModal
+        chatName={selectedChatName() || ''}
+        isOpen={openDeleteModal()}
+        onCancel={() => setIsOpenDeleteModal(false)}
+        onConfirm={handleConfirmDelete}
+      />
     </>
   );
 };

--- a/flowise-embed/src/features/menu/components/MenuButton.tsx
+++ b/flowise-embed/src/features/menu/components/MenuButton.tsx
@@ -5,7 +5,7 @@ interface MenuButtonProps {
 }
 export const MenuButton = (props: MenuButtonProps) => {
   return (
-    <button onClick={() => props.onClick && props.onClick()}>
+    <button class="menu-opener-button" onClick={() => props.onClick && props.onClick()}>
       <MenuIcon fillColor={props.fillColor} />
     </button>
   );

--- a/flowise-embed/src/utils/messageUtils.ts
+++ b/flowise-embed/src/utils/messageUtils.ts
@@ -55,6 +55,9 @@ Para iniciarmos a análise envie uma mensagem preenchendo os campos abaixo ou fa
 8. **Estado do Importador:**`,
   YES: 'Sim',
   NO: 'Não',
+  DELETE_CONFIRMATION: (chatName: string) => `Tem certeza que deseja excluir ${chatName}? Essa é uma ação permanente.`,
+  CANCEL_BUTTON: 'Cancelar',
+  DELETE_BUTTON: 'Excluir'
 };
 
 export function ncmChangeMessage(oldNcm: string, newNcm: string): string {

--- a/flowise-embed/src/utils/messageUtils.ts
+++ b/flowise-embed/src/utils/messageUtils.ts
@@ -57,7 +57,7 @@ Para iniciarmos a análise envie uma mensagem preenchendo os campos abaixo ou fa
   NO: 'Não',
   DELETE_CONFIRMATION: (chatName: string) => `Tem certeza que deseja excluir ${chatName}? Essa é uma ação permanente.`,
   CANCEL_BUTTON: 'Cancelar',
-  DELETE_BUTTON: 'Excluir'
+  DELETE_BUTTON: 'Excluir',
 };
 
 export function ncmChangeMessage(oldNcm: string, newNcm: string): string {

--- a/flowise-embed/src/utils/messageUtils.ts
+++ b/flowise-embed/src/utils/messageUtils.ts
@@ -75,3 +75,5 @@ export function complianceErrorMessage(errorMessages: string, isPlural: boolean)
 export function criticalAnalysisNcmPhase(ncm: string): string {
   return `Análise Crítica para o NCM: **${ncm}**`;
 }
+
+export const DEFAULT_CHAT_NAME = (date: Date) => `Sem título - ${date.toLocaleDateString()} ${date.toLocaleTimeString()}`

--- a/flowise-embed/src/utils/messageUtils.ts
+++ b/flowise-embed/src/utils/messageUtils.ts
@@ -76,4 +76,4 @@ export function criticalAnalysisNcmPhase(ncm: string): string {
   return `Análise Crítica para o NCM: **${ncm}**`;
 }
 
-export const DEFAULT_CHAT_NAME = (date: Date) => `Sem título - ${date.toLocaleDateString()} ${date.toLocaleTimeString()}`
+export const DEFAULT_CHAT_NAME = (date: Date) => `Sem título - ${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;


### PR DESCRIPTION
Desenvolver, no menu, a seção de histórico de chats conforme o Figma.

As funções de obter os chats, renomear e excluir, relacionadas ao banco, foram desenvolvidas na task [Suporte ao histórico de chats](https://startse.atlassian.net/browse/ACI-101.)

Adicionar ao menu:

Listagem de chats do tipo de fluxo atualmente aberto na tela (compliance, análise crítica, estimativa de custos)

Cada chat deve ter a opção de ser renomeado e excluído

Para novos chats, sem um título definido, exibir no menu “Sem título - <dd/mm/yyyy HH:MM>”