### PR TITLE
[CI-115] - [Compliance] Validação cruzada não sendo executada após os checklists em alguns casos

### DIFF
--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1815,7 +1815,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
         if (!Object.keys(jsonData).includes('checklist')) {
           throw new Error(messageUtils.CHECKLIST_NOT_FOUND_IN_RESPONSE_ERROR);
         }
-        documentService.saveDocumentData(fileMap, textContent, props.flow, chatId());
+        await documentService.saveDocumentData(fileMap, textContent, props.flow, chatId());
         structureAndSaveMessages(jsonData, fileMap, resultFromBackgroundMessage);
 
         break;


### PR DESCRIPTION
O erro era causado por que o tempo para salvar as extrações era maior do que o tempo em que o código recuperava os checklists no banco. Fazendo com que alguns documentos fossem ignorados. 