### PR TITLE
[ACI-119] - [Análise Crítica] Salvar mensagens no localStorage ao interagir com o assistente

### DIFF
--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -276,18 +276,21 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
 
   onMount(() => {
     if (props.flow === Flow.CriticalAnalysis.toString()) {
-      setMessages((prevMessages) => {
-        const newMessage = { message: messageUtils.CRITICAL_ANALYSIS_TEMPLATE, type: 'apiMessage' } as MessageType;
-        const updated = [...prevMessages, newMessage];
-        addChatMessage(updated);
-        return [...updated];
-      });
-      setMessages((prevMessages) => {
-        const newMessage = { message: messageUtils.NCM_INITIAL_QUESTION, type: 'selectionMessage' } as MessageType;
-        const updated = [...prevMessages, newMessage];
-        addChatMessage(updated);
-        return [...updated];
-      });
+      const chatHistoryReference = localStorage.getItem(props.chatflowid + '_EXTERNAL');
+      if (!chatHistoryReference) {
+        setMessages((prevMessages) => {
+          const newMessage = { message: messageUtils.CRITICAL_ANALYSIS_TEMPLATE, type: 'apiMessage' } as MessageType;
+          const updated = [...prevMessages, newMessage];
+          addChatMessage(updated);
+          return [...updated];
+        });
+        setMessages((prevMessages) => {
+          const newMessage = { message: messageUtils.NCM_INITIAL_QUESTION, type: 'selectionMessage' } as MessageType;
+          const updated = [...prevMessages, newMessage];
+          addChatMessage(updated);
+          return [...updated];
+        });
+      }
       setDisableInput(false);
       setDocumentsUploaded(true);
     }
@@ -902,7 +905,10 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     const lastUserMessage = messages().findLast((message) => message.type === 'userMessage')?.message;
 
     if ([messageUtils.NCM_INITIAL_QUESTION, messageUtils.NCM_CONTINUE_QUESTION, messageUtils.NCM_RETRY].includes(lastSelectionMessage ?? '')) {
-      setIsNcmDiscoveringStep(lastUserMessage === messageUtils.YES);
+      const chatHistoryReference = localStorage.getItem(props.chatflowid + '_EXTERNAL');
+      if (!chatHistoryReference) {
+        setIsNcmDiscoveringStep(lastUserMessage === messageUtils.YES);
+      }
     }
   });
 
@@ -1174,22 +1180,22 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       const loadedMessages: MessageType[] =
         chatMessage?.chatHistory?.length > 0
           ? chatMessage.chatHistory?.map((message: MessageType) => {
-            const chatHistory: MessageType = {
-              messageId: message?.messageId,
-              message: message.message,
-              type: message.type,
-              rating: message.rating,
-              dateTime: message.dateTime,
-            };
-            if (message.sourceDocuments) chatHistory.sourceDocuments = message.sourceDocuments;
-            if (message.fileAnnotations) chatHistory.fileAnnotations = message.fileAnnotations;
-            if (message.fileUploads) chatHistory.fileUploads = message.fileUploads;
-            if (message.agentReasoning) chatHistory.agentReasoning = message.agentReasoning;
-            if (message.action) chatHistory.action = message.action;
-            if (message.artifacts) chatHistory.artifacts = message.artifacts;
-            if (message.followUpPrompts) chatHistory.followUpPrompts = message.followUpPrompts;
-            return chatHistory;
-          })
+              const chatHistory: MessageType = {
+                messageId: message?.messageId,
+                message: message.message,
+                type: message.type,
+                rating: message.rating,
+                dateTime: message.dateTime,
+              };
+              if (message.sourceDocuments) chatHistory.sourceDocuments = message.sourceDocuments;
+              if (message.fileAnnotations) chatHistory.fileAnnotations = message.fileAnnotations;
+              if (message.fileUploads) chatHistory.fileUploads = message.fileUploads;
+              if (message.agentReasoning) chatHistory.agentReasoning = message.agentReasoning;
+              if (message.action) chatHistory.action = message.action;
+              if (message.artifacts) chatHistory.artifacts = message.artifacts;
+              if (message.followUpPrompts) chatHistory.followUpPrompts = message.followUpPrompts;
+              return chatHistory;
+            })
           : [{ message: props.welcomeMessage ?? defaultWelcomeMessage, type: 'apiMessage' }];
 
       const filteredMessages = loadedMessages.filter((message) => message.message !== '' && message.type !== 'leadCaptureMessage');
@@ -1742,11 +1748,10 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
           setHiddenInput(true);
           await processNextChecklist();
       }
-
     } finally {
-      setIsUploadButtonDisabled(false)
+      setIsUploadButtonDisabled(false);
     }
-  }
+  };
 
   const processFileToSend = async (file: File) => {
     let imagesList: File[] = [];

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -905,10 +905,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     const lastUserMessage = messages().findLast((message) => message.type === 'userMessage')?.message;
 
     if ([messageUtils.NCM_INITIAL_QUESTION, messageUtils.NCM_CONTINUE_QUESTION, messageUtils.NCM_RETRY].includes(lastSelectionMessage ?? '')) {
-      const chatHistoryReference = localStorage.getItem(props.chatflowid + '_EXTERNAL');
-      if (!chatHistoryReference) {
-        setIsNcmDiscoveringStep(lastUserMessage === messageUtils.YES);
-      }
+      setIsNcmDiscoveringStep(lastUserMessage === messageUtils.YES);
     }
   });
 


### PR DESCRIPTION
As mensagens trocadas com o assistente não estão sendo salvas no local storage atualmente, de modo que ao atualizar a tela o histórico é perdido. É preciso atualizar esse comportamento para que o histórico seja mantido.

[TASK](https://startse.atlassian.net/jira/software/c/projects/AA/boards/78?selectedIssue=ACI-119)