### PR TITLE
[ACI-139] - Corrigir validação de dados vindos do DB com null

### DIFF
--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1976,7 +1976,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       fileProcessed = await documentService.getProcessedDocumentData(fileMap, props.flow, chatId());
     }
 
-    if (fileProcessed != null) {
+    if (fileProcessed && fileProcessed != 'null') {
       let processedDocumentJson = JSON.parse(fileProcessed);
       processedDocumentJson = sanitizeJson(processedDocumentJson);
       structureAndSaveMessages(processedDocumentJson, fileMap);
@@ -2010,6 +2010,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   const executeComplianceCheck = async (filledChecklists: FileMapping[]) => {
     setCurrentChecklistNumber(0);
     setDocumentsUploaded(false);
+    const fileMappings = filledChecklists;
 
     if (documentsChecklistError().length > 0) {
       const errorMessages = documentsChecklistError().join(', ');
@@ -2028,19 +2029,22 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     }
     const filesCheckList = await documentService.getDocumentsByChatId(chatId());
 
-    const fileMappings: FileMapping[] = filesCheckList.map((file: any) => ({
-      file: {
-        name: file.file_name,
-        mime: file.mime,
-        hash: file.hash,
-      } as DatabaseProvidedFile,
-      type: file.checklist_type,
-      content: file.checklist_result,
-      filledChecklist: file.checklist_result,
-    }));
+    if (filesCheckList) {
+      const cacheFileMappings: FileMapping[] = filesCheckList.map((file: any) => ({
+        file: {
+          name: file.file_name,
+          mime: file.mime,
+          hash: file.hash,
+        } as DatabaseProvidedFile,
+        type: file.checklist_type,
+        content: file.checklist_result,
+        filledChecklist: file.checklist_result,
+      }));
+      fileMappings.push(...cacheFileMappings);
+    }
 
     const compareDocuments = new CompareDocuments({
-      fileMappings: fileMappings || filledChecklists,
+      fileMappings: fileMappings,
       sendBackgroundMessage,
       setMessages,
     });
@@ -2069,7 +2073,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
 
     const fileProcessed = await documentService.getProcessedDocumentData(fileMap, props.flow, chatId());
 
-    if (fileProcessed) {
+    if (fileProcessed && fileProcessed != 'null') {
       let processedDocumentJson = JSON.parse(fileProcessed);
       processedDocumentJson = sanitizeJson(processedDocumentJson);
       await processCriticalAnalysisUpdate(processedDocumentJson, true);


### PR DESCRIPTION
Foi modificado o fluxo do n8n  ‘GetDocumentsByChatId’ para que o mesmo retorne null caso não encontre nada e não mais [{}] como era feito anteriormente impossibilitando a validação de existência do objeto. E também verificado que a função que retornava os dados do supabase retornava como 'null' e não null, atualizada a validação, tudo funcionou.