### PR TITLE
[CI-140] - [Análise Crítica] Campos necessários não são exibidos após mensagem inicial

### DIFF
--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -290,27 +290,22 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
 
   onMount(async () => {
     await fetchAndProcessChatHistory();
-    if (props.flow === Flow.CriticalAnalysis.toString()) {
-      const chatHistoryReference = localStorage.getItem(props.chatflowid + '_EXTERNAL');
-      if (!chatHistoryReference) {
-        setMessages((prevMessages) => {
-          const newMessage = { message: messageUtils.CRITICAL_ANALYSIS_TEMPLATE, type: 'apiMessage' } as MessageType;
-          const updated = [...prevMessages, newMessage];
-          addChatMessage(updated);
-          return [...updated];
-        });
-      }
+    const minimumMessages = 2;
+    if (props.flow === Flow.CriticalAnalysis.toString() && messages().length < minimumMessages) {
+      setMessages((prevMessages) => {
+        const newMessage = { message: messageUtils.CRITICAL_ANALYSIS_TEMPLATE, type: 'apiMessage' } as MessageType;
+        const updated = [...prevMessages, newMessage];
+        addChatMessage(updated);
+        return [...updated];
+      });
     }
-    if (props.flow === Flow.taxClassification.toString()) {
-      const chatHistoryReference = localStorage.getItem(props.chatflowid + '_EXTERNAL');
-      if (!chatHistoryReference) {
-        setMessages((prevMessages) => {
-          const newMessage = { message: messageUtils.NCM_DISCOVER_TEMPLATE, type: 'apiMessage' } as MessageType;
-          const updated = [...prevMessages, newMessage];
-          addChatMessage(updated);
-          return [...updated];
-        });
-      }
+    if (props.flow === Flow.taxClassification.toString() && messages().length < minimumMessages) {
+      setMessages((prevMessages) => {
+        const newMessage = { message: messageUtils.NCM_DISCOVER_TEMPLATE, type: 'apiMessage' } as MessageType;
+        const updated = [...prevMessages, newMessage];
+        addChatMessage(updated);
+        return [...updated];
+      });
     }
     if (botProps?.observersConfig) {
       const { observeUserInput, observeLoading, observeMessages } = botProps.observersConfig;
@@ -2124,7 +2119,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       ((!!localStorageData?.chatId && localStorageData?.chatId !== chatId()) || localStorageData?.chatHistory?.length === 0)
     ) {
       const chatHistory = await historyChatFlowiseApi.getFlowiseChatHistory(props.apiHost, props.chatflowid, localStorageData?.chatId || null);
-      setChatId(localStorageData);
+      setChatId(localStorageData.chatId);
       const updatedMessages = processMessages(chatHistory);
       setLocalStorageChatflow(props.chatflowid, localStorageData?.chatId, { chatHistory: updatedMessages });
     }

--- a/flowise-embed/src/constants.ts
+++ b/flowise-embed/src/constants.ts
@@ -33,7 +33,7 @@ export const constants = {
   n8nFlowSendUpdateChatRequest: 'sendUpdateChatRequest',
   n8nFlowGetChatHistoryFromSupabase: 'getChatHistoryFromSupabase',
   n8nFlowSendUpdateChatHistoryRequest: 'sendUpdateChatHistoryRequest',
-  flowiseJwtToken: '_tICaLVIhVs6FTLM9mlyPdMCrZmL59JloDWH9KTC0hg',
+  flowiseJwtToken: 'mG8p9eQmqXinjexUIQq4bxKvnVq0A8oSeFSEC0_7lt8',
 };
 
 export const defaultMenuProps: MenuProps = {


### PR DESCRIPTION
Foi atualizado o setChatId para corrigir os erros de salvamento no histórico que causavam alguns bugs, além de ajustar a lógica de impressão dos templates na análise crítica e classificação fiscal, para correção de dois erros: Impressão do template várias vezes no mesmo chat e/ou a ausência da impressão algumas vezes. E também a atualização do flowiseToken.