### PR TITLE
[ACI-160] - [Classificação Fiscal] Mensagens iniciais não são recarregadas do histórico

### DIFF
--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -294,8 +294,6 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   });
 
   onMount(async () => {
-    console.log(chatId());
-    clearChat();
     await fetchAndProcessChatHistory();
     const minimumMessages = 2;
     if (props.flow === Flow.CriticalAnalysis.toString() && messages().length < minimumMessages) {
@@ -415,23 +413,6 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       allMessages.push({ message: props.errorMessage || errorMessage, type: 'apiMessage' });
       addChatMessage(allMessages);
       return allMessages;
-    });
-  };
-
-  const printCriticalAnalysisData = () => {
-    let criticalAnalysisMessage = `<b>${messageUtils.CRITICAL_ANALYSIS_REQUIRED_DATA_LABEL}</b><br>`;
-
-    for (const [key, value] of Object.entries(jsonResponseCriticalAnalysis())) {
-      criticalAnalysisMessage += generateItemToPrint(key, value as string, false);
-    }
-    setMessages((prevMessages) => {
-      const newMessage = {
-        message: Object.keys(jsonResponseCriticalAnalysis()).length === 0 ? messageUtils.CRITICAL_ANALYSIS_TEMPLATE : criticalAnalysisMessage,
-        type: 'apiMessage',
-      } as MessageType;
-      const updated = [...prevMessages, newMessage];
-      addChatMessage(updated);
-      return [...updated];
     });
   };
 
@@ -2229,6 +2210,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       setChatId(localStorageData.chatId);
       const updatedMessages = processMessages(chatHistory);
       setLocalStorageChatflow(props.chatflowid, localStorageData?.chatId, { chatHistory: updatedMessages });
+      setMessages(updatedMessages);
     }
   };
   const setInitialMessages = (messages: ChatMessage[]) => {

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -294,6 +294,8 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   });
 
   onMount(async () => {
+    console.log(chatId());
+    clearChat();
     await fetchAndProcessChatHistory();
     const minimumMessages = 2;
     if (props.flow === Flow.CriticalAnalysis.toString() && messages().length < minimumMessages) {
@@ -2229,9 +2231,23 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       setLocalStorageChatflow(props.chatflowid, localStorageData?.chatId, { chatHistory: updatedMessages });
     }
   };
+  const setInitialMessages = (messages: ChatMessage[]) => {
+    messages.push({ content: props.welcomeMessage || '', role: 'apiMessage' } as ChatMessage);
+    switch (props.flow) {
+      case Flow.CriticalAnalysis.toString():
+        messages.push({ content: messageUtils.CRITICAL_ANALYSIS_TEMPLATE, role: 'apiMessage' } as ChatMessage);
+        break;
+      case Flow.taxClassification.toString():
+        messages.push({ content: messageUtils.NCM_DISCOVER_TEMPLATE, role: 'apiMessage' } as ChatMessage);
+        break;
+    }
+    return messages;
+  };
 
   const processMessages = (historyMessages: ChatMessage[]) => {
-    const visibleMessages: ChatMessage[] = [];
+    let visibleMessages: ChatMessage[] = [];
+    visibleMessages = setInitialMessages(visibleMessages);
+
     let currentFileMap: FileMapping | null = null;
 
     for (const message of historyMessages) {

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -900,12 +900,6 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       addChatMessage(updated);
       return [...updated];
     });
-    setMessages((prevMessages) => {
-      const newMessage = { message: messageUtils.NCM_INPUT_INSTRUCTIONS, type: 'apiMessage' } as MessageType;
-      const updated = [...prevMessages, newMessage];
-      addChatMessage(updated);
-      return [...updated];
-    });
     setLoading(false);
   };
 
@@ -1167,6 +1161,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
         : uuidv4();
 
       setChatId(newChatId);
+      setLocalStorageChatflow(props.chatflowid, chatId());
       setUploadedFiles([]);
       window.location.reload();
 

--- a/flowise-embed/src/features/menu/Menu.tsx
+++ b/flowise-embed/src/features/menu/Menu.tsx
@@ -53,7 +53,7 @@ export const Menu = (props: MenuProps) => {
 
   createEffect(async () => {
     if (open()) {
-      fetchChatIds();
+      await getChatHistory();
     }
     if (props.currentFlow !== currentFlow()) {
       setCurrentFLow(props.currentFlow);


### PR DESCRIPTION
As mensagens enviadas inicialmente não são salvas no histórico, logo fiz um switch case para que por meio do atributo flow da props eu consiga setta lás antes do carregamento. Também foi feita a resolução do problema relacionado ao novo chat não ser settado como ativo no menu histórico, resolvemos por meio da substituição da função que é ativada no createEffect e o set do chatId no localStorage ao apertar o botão `Novo chat`.