### PR TITLE
[ACI-160] - [Classificação Fiscal] Mensagens iniciais não são recarregadas do histórico

### DIFF
--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -1161,7 +1161,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
         : uuidv4();
 
       setChatId(newChatId);
-      setLocalStorageChatflow(props.chatflowid, chatId());
+      setLocalStorageChatflow(props.chatflowid, newChatId);
       setUploadedFiles([]);
       window.location.reload();
 
@@ -2222,8 +2222,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   };
 
   const processMessages = (historyMessages: ChatMessage[]) => {
-    let visibleMessages: ChatMessage[] = [];
-    visibleMessages = setInitialMessages(visibleMessages);
+    const visibleMessages = setInitialMessages([]);
 
     let currentFileMap: FileMapping | null = null;
 

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -294,8 +294,6 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   });
 
   onMount(async () => {
-    console.log(chatId());
-    clearChat();
     await fetchAndProcessChatHistory();
     const minimumMessages = 2;
     if (props.flow === Flow.CriticalAnalysis.toString() && messages().length < minimumMessages) {
@@ -415,23 +413,6 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       allMessages.push({ message: props.errorMessage || errorMessage, type: 'apiMessage' });
       addChatMessage(allMessages);
       return allMessages;
-    });
-  };
-
-  const printCriticalAnalysisData = () => {
-    let criticalAnalysisMessage = `<b>${messageUtils.CRITICAL_ANALYSIS_REQUIRED_DATA_LABEL}</b><br>`;
-
-    for (const [key, value] of Object.entries(jsonResponseCriticalAnalysis())) {
-      criticalAnalysisMessage += generateItemToPrint(key, value as string, false);
-    }
-    setMessages((prevMessages) => {
-      const newMessage = {
-        message: Object.keys(jsonResponseCriticalAnalysis()).length === 0 ? messageUtils.CRITICAL_ANALYSIS_TEMPLATE : criticalAnalysisMessage,
-        type: 'apiMessage',
-      } as MessageType;
-      const updated = [...prevMessages, newMessage];
-      addChatMessage(updated);
-      return [...updated];
     });
   };
 
@@ -2229,6 +2210,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       setChatId(localStorageData.chatId);
       const updatedMessages = processMessages(chatHistory);
       setLocalStorageChatflow(props.chatflowid, localStorageData?.chatId, { chatHistory: updatedMessages });
+      setMessages(updatedMessages);
     }
   };
   const setInitialMessages = (messages: ChatMessage[]) => {

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -294,6 +294,8 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   });
 
   onMount(async () => {
+    console.log(chatId());
+    clearChat();
     await fetchAndProcessChatHistory();
     const minimumMessages = 2;
     if (props.flow === Flow.CriticalAnalysis.toString() && messages().length < minimumMessages) {
@@ -2229,9 +2231,23 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       setLocalStorageChatflow(props.chatflowid, localStorageData?.chatId, { chatHistory: updatedMessages });
     }
   };
+  const setInitialMessages = (messages: ChatMessage[]) => {
+    messages.push({ content: props.welcomeMessage || '', role: 'apiMessage' } as ChatMessage);
+    switch (props.flow) {
+      case Flow.CriticalAnalysis.toString():
+        messages.push({ content: messageUtils.CRITICAL_ANALYSIS_TEMPLATE, role: 'apiMessage' } as ChatMessage);
+        break;
+      case Flow.taxClassification.toString():
+        messages.push({ content: messageUtils.NCM_DISCOVER_TEMPLATE, role: 'apiMessage' } as ChatMessage);
+        break;
+    }
+    return messages;
+  };
 
   const processMessages = (historyMessages: ChatMessage[]) => {
-    const visibleMessages: ChatMessage[] = [];
+    let visibleMessages: ChatMessage[] = [];
+    visibleMessages = setInitialMessages(visibleMessages);
+
     let currentFileMap: FileMapping | null = null;
 
     for (const message of historyMessages) {

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -900,12 +900,6 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       addChatMessage(updated);
       return [...updated];
     });
-    setMessages((prevMessages) => {
-      const newMessage = { message: messageUtils.NCM_INPUT_INSTRUCTIONS, type: 'apiMessage' } as MessageType;
-      const updated = [...prevMessages, newMessage];
-      addChatMessage(updated);
-      return [...updated];
-    });
     setLoading(false);
   };
 
@@ -1167,6 +1161,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
         : uuidv4();
 
       setChatId(newChatId);
+      setLocalStorageChatflow(props.chatflowid, chatId());
       setUploadedFiles([]);
       window.location.reload();
 

--- a/flowise-embed/src/features/menu/Menu.tsx
+++ b/flowise-embed/src/features/menu/Menu.tsx
@@ -53,7 +53,7 @@ export const Menu = (props: MenuProps) => {
 
   createEffect(async () => {
     if (open()) {
-      fetchChatIds();
+      await getChatHistory();
     }
     if (props.currentFlow !== currentFlow()) {
       setCurrentFLow(props.currentFlow);


### PR DESCRIPTION
Foi adicionado um set das mensagens iniciais dos fluxos que é ativado ao recarregar o histórico, tais mensagens não são salvas no histórico do flowise. Para resolução do problema no menu histórico, substituimos o método de recarregamento de chats e settamos o chatId no localStorage ao apertar o botão de novo chat. A função 'printCriticalAnalysisData' foi retirada pois não estava sendo usada.