### PR TITLE
[ACI-163] - [Análise Crítica] Utilizar plain-text ao buscar dados para análise

### DIFF
--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -2194,7 +2194,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   async function processNewFileData(file: any, files: any[], urls: Partial<FileUpload>[]) {
     const textContent = await getTextContent(file.file);
 
-    const promptCriticalAnalysis = `VERIFICAR DADOS ANALISE CRITICA`;
+    const promptCriticalAnalysis = `VERIFICAR DADOS ANALISE CRITICA\n\nPlainText:${textContent} `;
     const dataFoundCriticalAnalysis = await sendBackgroundMessage(promptCriticalAnalysis, urls as any[]);
 
     for (const file of files) {


### PR DESCRIPTION
Adiciona plain text na question que é enviada para-o agente de Análise Crítica.