### PR TITLE
[ACI-167] - [Menu] Confirmar funcionamento do menu de histórico

### DIFF
--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -958,6 +958,9 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
         addChatMessage(updated);
         return [...updated];
       });
+      if (props.chatflowid && props.apiHost && chatId()) {
+        await historyChatFlowiseApi.setFlowiseChatHistory(props.apiHost, props.chatflowid, chatId(), criticalAnalysisMessage, ChatRole.apiMessage);
+      }
 
       if (criticalAnalysisMessage.includes(messageUtils.DATA_NOT_FOUND)) {
         setLoading(false);
@@ -2291,7 +2294,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
         const keywordsToIgnore = ['CROSS_VALIDATION', 'LIST_DIFFERENT_KEYS', 'Specific compliance', 'ANALISE_\\d##'];
         const discoverNCMKeyword = 'DESCOBRE_NCM';
         const userKeywordsTextToReformat = ['CORRIGE_JSON', discoverNCMKeyword];
-        const userKeywordsFileToReformat = ['CHECKLIST', 'EXTRACTION'];
+        const userKeywordsFileToReformat = ['CHECKLIST', 'EXTRACTION', 'VERIFICAR DADOS ANALISE CRITICA'];
         const userKeywordsToReformat = [...userKeywordsFileToReformat, ...userKeywordsTextToReformat];
         const ignoreRegex = new RegExp(`^(${keywordsToIgnore.join('|')})`);
         const shouldIgnoreMessage = ignoreRegex.test(message.content);

--- a/flowise-embed/src/components/Bot.tsx
+++ b/flowise-embed/src/components/Bot.tsx
@@ -952,18 +952,29 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
         criticalAnalysisMessage += generateItemToPrint(key, value as string);
       }
 
+      historyChatFlowiseApi.setFlowiseChatHistory(props.apiHost ?? '', props.chatflowid, chatId(), criticalAnalysisMessage, ChatRole.apiMessage);
       setMessages((prevMessages) => {
         const newMessage = { message: criticalAnalysisMessage, type: 'apiMessage' } as MessageType;
         const updated = [...prevMessages, newMessage];
         addChatMessage(updated);
         return [...updated];
       });
-      if (props.chatflowid && props.apiHost && chatId()) {
-        await historyChatFlowiseApi.setFlowiseChatHistory(props.apiHost, props.chatflowid, chatId(), criticalAnalysisMessage, ChatRole.apiMessage);
-      }
-
       if (criticalAnalysisMessage.includes(messageUtils.DATA_NOT_FOUND)) {
         setLoading(false);
+        historyChatFlowiseApi.setFlowiseChatHistory(
+          props.apiHost ?? '',
+          props.chatflowid,
+          chatId(),
+          messageUtils.CRITICAL_ANALYSIS_MISSING_DATA,
+          ChatRole.apiMessage,
+        );
+        historyChatFlowiseApi.setFlowiseChatHistory(
+          props.apiHost ?? '',
+          props.chatflowid,
+          chatId(),
+          messageUtils.CRITICAL_ANALYSIS_MISSING_NCM,
+          ChatRole.apiMessage,
+        );
         setMessages((prevMessages) => {
           const newMessage = { message: messageUtils.CRITICAL_ANALYSIS_MISSING_DATA, type: 'apiMessage' } as MessageType;
           const updated = [...prevMessages, newMessage];
@@ -989,10 +1000,13 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
 
         if (validatedNcmArray.isNotNcm.length) {
           const isPlural = validatedNcmArray.isNotNcm.length > 1;
+          const errorMessage = criticalAnalysisNcmErrorMessage(ncmErrorsArray, isPlural);
           let criticalAnalysisMessage = `<b>${messageUtils.CRITICAL_ANALYSIS_REQUIRED_DATA_LABEL}</b><br>`;
           for (const [key, value] of Object.entries(jsonDataCriticalAnalysis)) {
             criticalAnalysisMessage += generateItemToPrint(key, value as string);
           }
+          historyChatFlowiseApi.setFlowiseChatHistory(props.apiHost ?? '', props.chatflowid, chatId(), criticalAnalysisMessage, ChatRole.apiMessage);
+          historyChatFlowiseApi.setFlowiseChatHistory(props.apiHost ?? '', props.chatflowid, chatId(), errorMessage, ChatRole.apiMessage);
           setMessages((prevMessages) => {
             const newMessage = { message: criticalAnalysisMessage, type: 'apiMessage' } as MessageType;
             const updated = [...prevMessages, newMessage];
@@ -1000,7 +1014,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
             return [...updated];
           });
           setMessages((prevMessages) => {
-            const newMessage = { message: criticalAnalysisNcmErrorMessage(ncmErrorsArray, isPlural), type: 'apiMessage' } as MessageType;
+            const newMessage = { message: errorMessage, type: 'apiMessage' } as MessageType;
             const updated = [...prevMessages, newMessage];
             addChatMessage(updated);
             return [...updated];
@@ -1008,7 +1022,13 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
           setLoading(false);
           return;
         }
-
+        historyChatFlowiseApi.setFlowiseChatHistory(
+          props.apiHost ?? '',
+          props.chatflowid,
+          chatId(),
+          messageUtils.CRITICAL_ANALYSIS_SUBMISSION_SUCCESS,
+          ChatRole.apiMessage,
+        );
         setMessages((prevMessages) => {
           const newMessage = { message: messageUtils.CRITICAL_ANALYSIS_SUBMISSION_SUCCESS, type: 'apiMessage' } as MessageType;
           const updated = [...prevMessages, newMessage];
@@ -1068,6 +1088,14 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       isNcm: [],
       isNotNcm: [],
     };
+    historyChatFlowiseApi.setFlowiseChatHistory(
+      props.apiHost ?? '',
+      props.chatflowid,
+      chatId(),
+      messageUtils.CRITICAL_ANALYSIS_NCM_VALIDATION,
+      ChatRole.apiMessage,
+    );
+
     setMessages((prevMessages) => {
       const newMessage = { message: messageUtils.CRITICAL_ANALYSIS_NCM_VALIDATION, type: 'apiMessage' } as MessageType;
       const updated = [...prevMessages, newMessage];
@@ -1076,6 +1104,8 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     });
     for (const ncm of ncmArray) {
       const validatedNCM = await isNCM(ncm);
+      historyChatFlowiseApi.setFlowiseChatHistory(props.apiHost ?? '', props.chatflowid, chatId(), validatedNCM.message, ChatRole.apiMessage);
+
       if (validatedNCM.valid === false) {
         validationResults.isNotNcm.push(validatedNCM);
       } else {
@@ -1696,10 +1726,14 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   const readImagesUrls = (imagesToUpload: any[]) => {
     // Logic from handleSubmit function
     const urls = imagesToUpload.map((item, index) => {
+      const nameParts = item.name.split('.');
+      const extension = nameParts.pop();
+      const baseName = nameParts.join('.');
+      const newName = `${baseName}${index}.${extension}`;
       return {
         data: item.data,
         type: item.type,
-        name: item.name.split('.')[0] + index + '.' + item.name.split('.')[1],
+        name: newName,
         mime: item.mime,
       };
     });
@@ -1831,6 +1865,13 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
         setIsUploadButtonDisabled(false);
         break;
       default:
+        historyChatFlowiseApi.setFlowiseChatHistory(
+          props.apiHost ?? '',
+          props.chatflowid,
+          chatId(),
+          messageUtils.ALL_DOCUMENTS_VALIDATED_MESSAGE,
+          ChatRole.apiMessage,
+        );
         setMessages((prevMessages) => {
           const newMessage = { message: messageUtils.ALL_DOCUMENTS_VALIDATED_MESSAGE, type: 'apiMessage' } as MessageType;
           const updated = [...prevMessages, newMessage];
@@ -1873,6 +1914,13 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     const maxAttempts = 3;
 
     if ([DocumentTypes.LICENCA_DE_IMPORTACAO, DocumentTypes.LPCO].includes(fileMap.type)) {
+      historyChatFlowiseApi.setFlowiseChatHistory(
+        props.apiHost ?? '',
+        props.chatflowid,
+        chatId(),
+        messageUtils.NO_LI_LPCO_COMPLIANCE_FEATURE,
+        ChatRole.apiMessage,
+      );
       setMessages((prevMessages) => {
         const newMessage = { message: messageUtils.NO_LI_LPCO_COMPLIANCE_FEATURE, type: 'apiMessage' } as MessageType;
         const updated = [...prevMessages, newMessage];
@@ -1884,6 +1932,13 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       return;
     }
     if (fileMap.type === DocumentTypes.COMMERCIAL_INVOICE) {
+      historyChatFlowiseApi.setFlowiseChatHistory(
+        props.apiHost ?? '',
+        props.chatflowid,
+        chatId(),
+        messageUtils.MANUAL_COMPLIANCE_ALERT,
+        ChatRole.apiMessage,
+      );
       setMessages((prevMessages) => {
         const newMessage = { message: messageUtils.MANUAL_COMPLIANCE_ALERT, type: 'apiMessage' } as MessageType;
         const updated = [...prevMessages, newMessage];
@@ -1939,6 +1994,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
         console.error(error);
         if (attempt === maxAttempts) {
           const errorMessage = messageUtils.UNABLE_TO_PROCESS_CHECKLIST_MESSAGE;
+          historyChatFlowiseApi.setFlowiseChatHistory(props.apiHost ?? '', props.chatflowid, chatId(), errorMessage, ChatRole.apiMessage);
 
           const documentErrors = [...documentsChecklistError()];
           documentErrors.push(fileMap.file.name);
@@ -2022,10 +2078,8 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   };
 
   const saveCacheExtractionMessages = async (fileName: any, fileResults: any) => {
-    if (props.apiHost && props.chatflowid && chatId()) {
-      await historyChatFlowiseApi.setFlowiseChatHistory(props.apiHost, props.chatflowid, chatId(), fileName, ChatRole.userMessage);
-      await historyChatFlowiseApi.setFlowiseChatHistory(props.apiHost, props.chatflowid, chatId(), fileResults, ChatRole.apiMessage);
-    }
+    await historyChatFlowiseApi.setFlowiseChatHistory(props.apiHost ?? '', props.chatflowid, chatId(), fileName, ChatRole.userMessage);
+    await historyChatFlowiseApi.setFlowiseChatHistory(props.apiHost ?? '', props.chatflowid, chatId(), fileResults, ChatRole.apiMessage);
   };
 
   const showChecklistMessage = (jsonData: any, checklistMessage: string) => {
@@ -2117,7 +2171,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     } catch (error) {
       console.error(error);
       const errorMessage = messageUtils.UNABLE_TO_PROCESS_CROSS_VALIDATION_MESSAGE;
-
+      historyChatFlowiseApi.setFlowiseChatHistory(props.apiHost ?? '', props.chatflowid, chatId(), errorMessage, ChatRole.apiMessage);
       setMessages((prevMessages) => {
         const newMessage = { message: errorMessage, type: 'apiMessage' } as MessageType;
         const updated = [...prevMessages, newMessage];

--- a/flowise-embed/src/service/historyChatFlowiseAPI.ts
+++ b/flowise-embed/src/service/historyChatFlowiseAPI.ts
@@ -80,23 +80,25 @@ export class historyChatFlowiseAPI {
 
   async setFlowiseChatHistory(apiHost: string, chatFlowId: string, chatHistoryId: string, data: string, role: string) {
     try {
-      const body = {
-        chatflowid: chatFlowId,
-        chatId: chatHistoryId,
-        role: role,
-        content: data,
-      };
+      if (chatFlowId && apiHost && chatHistoryId) {
+        const body = {
+          chatflowid: chatFlowId,
+          chatId: chatHistoryId,
+          role: role,
+          content: data,
+        };
 
-      const response = await fetch(`${apiHost}/api/v1/chatmessage/`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `${constants.flowiseJwtToken}`,
-        },
-        body: JSON.stringify(body),
-      });
+        const response = await fetch(`${apiHost}/api/v1/chatmessage/`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `${constants.flowiseJwtToken}`,
+          },
+          body: JSON.stringify(body),
+        });
 
-      await response.json();
+        await response.json();
+      }
     } catch (error) {
       console.error('Error setting chat history:', error);
       throw error;

--- a/flowise-embed/src/utils/messageUtils.ts
+++ b/flowise-embed/src/utils/messageUtils.ts
@@ -10,8 +10,6 @@ export const messageUtils = {
   NEW_CHAT_BUTTON_LABEL: 'Novo chat',
   UPLOAD_LIMIT: 'Limite de arquivos:',
   SUPPORTED_FILE_TYPES: 'Formatos suportados:',
-  ANY_DOCUMENT_WITHOUT_CHECKLIST_MESSAGE:
-    'Um ou mais arquivos não puderam ter seu checklist identificado, mas os demais serão processados normalmente.',
   ALL_DOCUMENTS_VALIDATED_MESSAGE: 'Todos os seus documentos foram reconhecidos! Verifique cada um dos checklists abaixo detalhadamente',
   UNABLE_TO_PROCESS_CHECKLIST_MESSAGE: 'Não foi possível verificar o checklist deste arquivo.',
   UNABLE_TO_PROCESS_CROSS_VALIDATION_MESSAGE: 'Não foi possível verificar os campos deste arquivo.',


### PR DESCRIPTION
Nessa task, a ideia inicial era validar a questão do histórico após relatarem que o resultado do compliance e das extrações não estava sendo salvo, embora houvesse outros chats salvos no próprio menu History. Porém, não foi possível replicar o erro e, durante a tentativa, foi identificado um problema no histórico da análise crítica, onde o template preenchido, usado para a realização das etapas da análise crítica, não estava sendo salvo.
Com essa mudança, agora será possível acompanhar melhor os dados e métricas utilizados na realização das etapas de análise. Além disso, na função processMessages, adicionamos a frase "VERIFICAR DADOS ANÁLISE CRÍTICA" ao array userKeywordsFileToReformat para que ele fosse formatado corretamente e não exibisse o plainText e seu prompt ao recuperarmos o histórico.
Antes:
![image](https://github.com/user-attachments/assets/ebe4f222-a4fb-4ee8-be88-13cc91392197)
Depois: 
![image](https://github.com/user-attachments/assets/223a5647-11f2-4070-95af-4f51af677436)
